### PR TITLE
BDOG-25 Refactor service-dependencies

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/SchedulerModule.scala
+++ b/app/uk/gov/hmrc/servicedependencies/SchedulerModule.scala
@@ -22,5 +22,6 @@ class SchedulerModule() extends AbstractModule {
   override def configure(): Unit = {
     bind(classOf[DataReloadScheduler]).asEagerSingleton()
     bind(classOf[MetricsScheduler]).asEagerSingleton()
+    bind(classOf[Github]).toProvider(classOf[GithubProvider])
   }
 }

--- a/app/uk/gov/hmrc/servicedependencies/connector/GithubConnector.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/GithubConnector.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.servicedependencies.connector
+import com.kenshoo.play.metrics.Metrics
+import javax.inject.{Inject, Singleton}
+import org.slf4j.LoggerFactory
+import uk.gov.hmrc.githubclient.{ExtendedContentsService, ExtendedGitHubClient, GithubClientMetrics, ReleaseService}
+import uk.gov.hmrc.servicedependencies.Github
+import uk.gov.hmrc.servicedependencies.config.ServiceDependenciesConfig
+import uk.gov.hmrc.servicedependencies.config.model.{CuratedDependencyConfig, SbtPluginConfig}
+import uk.gov.hmrc.servicedependencies.connector.model.RepositoryInfo
+import uk.gov.hmrc.servicedependencies.model._
+import uk.gov.hmrc.time.DateTimeUtils
+
+@Singleton
+class GithubConnector @Inject() (config: ServiceDependenciesConfig, metrics: Metrics) {
+
+  lazy val logger = LoggerFactory.getLogger(this.getClass)
+
+  def now = DateTimeUtils.now
+
+  // Github client setup
+  private lazy val client: ExtendedGitHubClient = ExtendedGitHubClient(config.githubApiOpenConfig.apiUrl, new GithubMetrics("github.open"))
+    .setOAuth2Token(config.githubApiOpenConfig.key)
+    .asInstanceOf[ExtendedGitHubClient]
+
+  lazy val github: Github = new Github(new ReleaseService(client), new ExtendedContentsService(client))
+
+  class GithubMetrics(override val metricName: String) extends GithubClientMetrics {
+    lazy val registry = metrics.defaultRegistry
+    override def increment(name: String): Unit =
+      registry.counter(name).inc()
+  }
+
+
+  // github api helpers
+  def findOtherDependencies(githubSearchResults: GithubSearchResults): Seq[MongoRepositoryDependency] = {
+    githubSearchResults.others.foldLeft(Seq.empty[MongoRepositoryDependency]) {
+      case (acc, (library, Some(currentVersion))) => acc :+ MongoRepositoryDependency(library, currentVersion)
+      case (acc, (_, None)) => acc
+    }
+  }
+
+  def findPluginDependencies(githubSearchResults: GithubSearchResults): Seq[MongoRepositoryDependency] = {
+    githubSearchResults.sbtPlugins.foldLeft(Seq.empty[MongoRepositoryDependency]) {
+      case (acc, (library, Some(currentVersion))) => acc :+ MongoRepositoryDependency(library, currentVersion)
+      case (acc, (_, None)) => acc
+    }
+  }
+
+  def findLatestLibrariesVersions(githubSearchResults: GithubSearchResults): Seq[MongoRepositoryDependency] = {
+    githubSearchResults.libraries.foldLeft(Seq.empty[MongoRepositoryDependency]) {
+      case (acc, (library, Some(currentVersion))) => acc :+ MongoRepositoryDependency(library, currentVersion)
+      case (acc, (_, None)) => acc
+    }
+  }
+
+
+  def findLatestSbtPluginVersion(sbtPluginConfig: SbtPluginConfig) : Option[SbtPluginVersion] = {
+    github.findLatestVersion(sbtPluginConfig.name).map(v => SbtPluginVersion(sbtPluginConfig.name, Some(v)))
+  }
+
+  def findLatestLibraryVersion(lib: String): Option[LibraryVersion] = {
+    github.findLatestVersion(lib).map(version => LibraryVersion(lib, Some(version)))
+  }
+
+
+  def buildDependencies(repo: RepositoryInfo, curatedDeps: CuratedDependencyConfig): Option[MongoRepositoryDependencies] = {
+
+    github.findVersionsForMultipleArtifacts(repo.name, curatedDeps)
+      .right
+      .map(searchResults => {
+      MongoRepositoryDependencies(
+        repositoryName        = repo.name,
+        libraryDependencies   = findLatestLibrariesVersions(searchResults),
+        sbtPluginDependencies = findPluginDependencies(searchResults),
+        otherDependencies     = findOtherDependencies(searchResults),
+        updateDate            = now)})
+    match {
+      case Left(errorMessage) => {
+        logger.error(s"Skipping dependencies update for ${repo.name}, reason: $errorMessage")
+        None
+      }
+      case Right(results) => {
+        logger.debug(s"Github search returned these results for ${repo.name}: $results")
+        Some(results)
+      }
+    }
+  }
+}

--- a/app/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnector.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnector.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.servicedependencies.connector
 
 import com.google.inject.{Inject, Singleton}
-import play.api.libs.json._
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import uk.gov.hmrc.servicedependencies.config.ServiceDependenciesConfig
@@ -42,7 +42,7 @@ class TeamsAndRepositoriesConnector @Inject()(httpClient: HttpClient, serviceCon
   val teamsAndRepositoriesApiBase = serviceConfiguration.teamsAndRepositoriesServiceUrl
 
   implicit val formats = Repository.format
-  implicit val infoFormats = RepositoryInfo.format
+  implicit val repositoryInfoFormats = RepositoryInfo.format
 
   def getRepository(repositoryName: String)(implicit hc: HeaderCarrier): Future[Option[Repository]] =
     httpClient.GET[Option[Repository]](s"$teamsAndRepositoriesApiBase/api/repositories/$repositoryName")

--- a/app/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnector.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnector.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.servicedependencies.connector
 
 import com.google.inject.{Inject, Singleton}
-import play.api.libs.json.Json
+import play.api.libs.json._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import uk.gov.hmrc.servicedependencies.config.ServiceDependenciesConfig
-import uk.gov.hmrc.servicedependencies.connector.model.Repository
+import uk.gov.hmrc.servicedependencies.connector.model.{Repository, RepositoryInfo}
 import scala.concurrent.Future
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 
@@ -42,6 +42,7 @@ class TeamsAndRepositoriesConnector @Inject()(httpClient: HttpClient, serviceCon
   val teamsAndRepositoriesApiBase = serviceConfiguration.teamsAndRepositoriesServiceUrl
 
   implicit val formats = Repository.format
+  implicit val infoFormats = RepositoryInfo.format
 
   def getRepository(repositoryName: String)(implicit hc: HeaderCarrier): Future[Option[Repository]] =
     httpClient.GET[Option[Repository]](s"$teamsAndRepositoriesApiBase/api/repositories/$repositoryName")
@@ -53,6 +54,9 @@ class TeamsAndRepositoriesConnector @Inject()(httpClient: HttpClient, serviceCon
     httpClient.GET(s"$teamsAndRepositoriesApiBase/api/repositories") map { response =>
       (response.json \\ "name").map(_.as[String])
     }
+
+  def getAllRepositoryInfos()(implicit hc: HeaderCarrier): Future[Seq[RepositoryInfo]] =
+    httpClient.GET[Seq[RepositoryInfo]](s"$teamsAndRepositoriesApiBase/api/repositories")
 
   def getTeamsWithRepositories()(implicit hc: HeaderCarrier): Future[Seq[Team]] =
     httpClient.GET[Seq[Team]](s"$teamsAndRepositoriesApiBase/api/teams_with_repositories")

--- a/app/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnector.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnector.scala
@@ -50,12 +50,7 @@ class TeamsAndRepositoriesConnector @Inject()(httpClient: HttpClient, serviceCon
   def getTeamsForServices()(implicit hc: HeaderCarrier): Future[Map[String, Seq[String]]] =
     httpClient.GET[Map[String, Seq[String]]](s"$teamsAndRepositoriesApiBase/api/services?teamDetails=true")
 
-  def getAllRepositories()(implicit hc: HeaderCarrier): Future[Seq[String]] =
-    httpClient.GET(s"$teamsAndRepositoriesApiBase/api/repositories") map { response =>
-      (response.json \\ "name").map(_.as[String])
-    }
-
-  def getAllRepositoryInfos()(implicit hc: HeaderCarrier): Future[Seq[RepositoryInfo]] =
+  def getAllRepositories()(implicit hc: HeaderCarrier): Future[Seq[RepositoryInfo]] =
     httpClient.GET[Seq[RepositoryInfo]](s"$teamsAndRepositoriesApiBase/api/repositories")
 
   def getTeamsWithRepositories()(implicit hc: HeaderCarrier): Future[Seq[Team]] =

--- a/app/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnector.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnector.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import uk.gov.hmrc.servicedependencies.config.ServiceDependenciesConfig
 import uk.gov.hmrc.servicedependencies.connector.model.{Repository, RepositoryInfo}
 import scala.concurrent.Future
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 case class Team(
   name: String,

--- a/app/uk/gov/hmrc/servicedependencies/connector/model/RepositoryInfo.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/model/RepositoryInfo.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.servicedependencies.connector.model
 
 

--- a/app/uk/gov/hmrc/servicedependencies/connector/model/RepositoryInfo.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/model/RepositoryInfo.scala
@@ -1,0 +1,16 @@
+package uk.gov.hmrc.servicedependencies.connector.model
+
+
+import org.joda.time.DateTime
+import play.api.libs.json._
+
+case class RepositoryInfo(name:String, createdAt: DateTime, lastUpdatedAt:DateTime, repoType:String= "Other", language:Option[String] = None)
+
+object RepositoryInfo {
+
+  val pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+  implicit val dateFormat: Format[DateTime] = Format[DateTime](JodaReads.jodaDateReads(pattern), JodaWrites.jodaDateWrites(pattern))
+
+  implicit val format: OFormat[RepositoryInfo] = Json.using[Json.WithDefaultValues].format[RepositoryInfo]
+
+}

--- a/app/uk/gov/hmrc/servicedependencies/service/DependenciesDataSource.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/DependenciesDataSource.scala
@@ -79,7 +79,7 @@ class DependenciesDataSource @Inject()(
     force: Boolean = false)(implicit hc: HeaderCarrier): Future[Seq[MongoRepositoryDependencies]] = {
 
     teamsAndRepositoriesConnector
-      .getAllRepositoryInfos()
+      .getAllRepositories()
       .map(repos => {
         logger.debug(s"loading dependencies for ${repos.length} repositories")
         repos.flatMap(r => buildDependency(r, curatedDependencyConfig, currentDependencyEntries, force))

--- a/app/uk/gov/hmrc/servicedependencies/service/DependenciesDataSource.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/DependenciesDataSource.scala
@@ -17,17 +17,14 @@
 package uk.gov.hmrc.servicedependencies.service
 
 import com.google.inject.{Inject, Singleton}
-import com.kenshoo.play.metrics.Metrics
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import scala.concurrent.ExecutionContext.Implicits.global
-import uk.gov.hmrc.githubclient._
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.servicedependencies._
 import uk.gov.hmrc.servicedependencies.config.ServiceDependenciesConfig
 import uk.gov.hmrc.servicedependencies.config.model.{CuratedDependencyConfig, SbtPluginConfig}
-import uk.gov.hmrc.servicedependencies.connector.TeamsAndRepositoriesConnector
-import uk.gov.hmrc.servicedependencies.connector.model.Repository
+import uk.gov.hmrc.servicedependencies.connector.{GithubConnector, TeamsAndRepositoriesConnector}
+import uk.gov.hmrc.servicedependencies.connector.model.RepositoryInfo
 import uk.gov.hmrc.servicedependencies.model._
 import uk.gov.hmrc.servicedependencies.persistence.RepositoryLibraryDependenciesRepository
 import uk.gov.hmrc.time.DateTimeUtils
@@ -37,126 +34,63 @@ import scala.concurrent.Future
 class DependenciesDataSource @Inject()(
   teamsAndRepositoriesConnector: TeamsAndRepositoriesConnector,
   config: ServiceDependenciesConfig,
-  repositoryLibraryDependenciesRepository: RepositoryLibraryDependenciesRepository,
-  metrics: Metrics) {
+  github: GithubConnector,
+  repoLibDepRepository: RepositoryLibraryDependenciesRepository) {
+
 
   lazy val logger = LoggerFactory.getLogger(this.getClass)
 
   def now = DateTimeUtils.now
 
-  class GithubMetrics(override val metricName: String) extends GithubClientMetrics {
+  def prepDependency(repo: RepositoryInfo,
+                        curatedDependencyConfig: CuratedDependencyConfig,
+                        currentDeps: Seq[MongoRepositoryDependencies],
+                        force: Boolean): Option[MongoRepositoryDependencies] = {
 
-    lazy val registry = metrics.defaultRegistry
-
-    override def increment(name: String): Unit =
-      registry.counter(name).inc()
-  }
-
-  private lazy val client: ExtendedGitHubClient = ExtendedGitHubClient(config.githubApiOpenConfig.apiUrl, new GithubMetrics("github.open"))
-    .setOAuth2Token(config.githubApiOpenConfig.key)
-    .asInstanceOf[ExtendedGitHubClient]
-
-  lazy val github: Github = new Github(new ReleaseService(client), new ExtendedContentsService(client))
-
-  def getLatestSbtPluginVersions(sbtPlugins: Seq[SbtPluginConfig]): Seq[SbtPluginVersion] = {
-
-    def getLatestSbtPluginVersion(sbtPluginConfig: SbtPluginConfig): Option[Version] =
-      github.findLatestVersion(sbtPluginConfig.name)
-
-    sbtPlugins.map(sbtPluginConfig => sbtPluginConfig -> getLatestSbtPluginVersion(sbtPluginConfig)).map {
-      case (sbtPluginConfig, version) => SbtPluginVersion(sbtPluginConfig.name, version)
+    if (!force && lastUpdated(repo.name, currentDeps).isAfter(repo.lastUpdatedAt)) {
+      logger.debug(s"No changes for repository (${repo.name}). Skipping....")
+      None
+    } else {
+      logger.debug(s"building repo for ${repo.name}")
+      github.buildDependencies(repo, curatedDependencyConfig)
     }
 
   }
 
-  def getLatestLibrariesVersions(libraries: Seq[String]): Seq[LibraryVersion] = {
-
-    def getLatestLibraryVersion(lib: String): Option[Version] =
-      github.findLatestVersion(lib)
-
-    libraries.map(lib => lib -> getLatestLibraryVersion(lib)).map {
-      case (lib, version) => LibraryVersion(lib, version)
-    }
+  private def lastUpdated(repoName: String, currentDeps: Seq[MongoRepositoryDependencies]): DateTime = {
+    currentDeps.find(_.repositoryName == repoName)
+      .map(_.updateDate)
+      .getOrElse(new DateTime(0))
   }
+
+
+  private def serialiseFutures[A, B](l: Iterable[A])(fn: A => Future[B]): Future[Seq[B]] =
+    l.foldLeft(Future(List.empty[B])) { (previousFuture, next) ⇒
+      for {
+        previousResults ← previousFuture
+        next ← fn(next)
+      } yield previousResults :+ next
+    }
 
   def persistDependenciesForAllRepositories(
     curatedDependencyConfig: CuratedDependencyConfig,
     currentDependencyEntries: Seq[MongoRepositoryDependencies],
     force: Boolean = false)(implicit hc: HeaderCarrier): Future[Seq[MongoRepositoryDependencies]] = {
 
-    val allRepositories: Future[Seq[String]] = teamsAndRepositoriesConnector.getAllRepositories()
-
-    def serialiseFutures[A, B](l: Iterable[A])(fn: A => Future[B]): Future[Seq[B]] =
-      l.foldLeft(Future(List.empty[B])) { (previousFuture, next) ⇒
-        for {
-          previousResults ← previousFuture
-          next ← fn(next)
-        } yield previousResults :+ next
-      }
-
-    def getRepoAndUpdate(repositoryName: String): Future[Option[MongoRepositoryDependencies]] =
-      teamsAndRepositoriesConnector
-        .getRepository(repositoryName)
-        .map(maybeRepository => maybeRepository.flatMap(updateDependencies))
-
-    def updateDependencies(repository: Repository): Option[MongoRepositoryDependencies] = {
-
-      def getLibraryDependencies(githubSearchResults: GithubSearchResults) =
-        githubSearchResults.libraries.foldLeft(Seq.empty[MongoRepositoryDependency]) {
-          case (acc, (library, mayBeVersion)) =>
-            mayBeVersion.fold(acc)(currentVersion => acc :+ MongoRepositoryDependency(library, currentVersion))
-        }
-
-      def getPluginDependencies(githubSearchResults: GithubSearchResults) =
-        githubSearchResults.sbtPlugins.foldLeft(Seq.empty[MongoRepositoryDependency]) {
-          case (acc, (plugin, mayBeVersion)) =>
-            mayBeVersion.fold(acc)(currentVersion => acc :+ MongoRepositoryDependency(plugin, currentVersion))
-        }
-
-      def getOtherDependencies(githubSearchResults: GithubSearchResults) =
-        githubSearchResults.others.foldLeft(Seq.empty[MongoRepositoryDependency]) {
-          case (acc, ("sbt", mayBeVersion)) =>
-            mayBeVersion.fold(acc)(currentVersion => acc :+ MongoRepositoryDependency("sbt", currentVersion))
-        }
-
-      val repoName = repository.name
-      logger.info(s"Updating dependencies for: $repoName")
-      val lastUpdated: DateTime =
-        currentDependencyEntries.find(_.repositoryName == repoName).map(_.updateDate).getOrElse(new DateTime(0))
-      if (!force && lastUpdated.isAfter(repository.lastActive)) {
-        logger.debug(s"No changes for repository ($repoName). Skipping....")
-        None
-      } else {
-        logger.debug(s"searching GitHub for dependencies of ${repository.name}")
-
-        val dependencies = github.findVersionsForMultipleArtifacts(repository.name, curatedDependencyConfig)
-
-        dependencies match {
-          case Left(errorMessage) =>
-            logger.error(s"Skipping dependencies update for $repoName, reason: $errorMessage")
-            None
-          case Right(searchResults) =>
-            logger.debug(s"Github search returned these results for ${repository.name}: $searchResults")
-
-            val repositoryLibraryDependencies =
-              MongoRepositoryDependencies(
-                repositoryName        = repoName,
-                libraryDependencies   = getLibraryDependencies(searchResults),
-                sbtPluginDependencies = getPluginDependencies(searchResults),
-                otherDependencies     = getOtherDependencies(searchResults),
-                updateDate            = now
-              )
-
-            repositoryLibraryDependenciesRepository.update(repositoryLibraryDependencies)
-
-            Some(repositoryLibraryDependencies)
-        }
-
-      }
-    }
-
-    allRepositories.flatMap(serialiseFutures(_)(getRepoAndUpdate).map(_.flatten))
-
+    teamsAndRepositoriesConnector
+      .getAllRepositoryInfos()
+      .map(repos => {
+        logger.debug(s"loading dependencies for ${repos.length} repositories")
+        repos.flatMap(r => prepDependency(r, curatedDependencyConfig, currentDependencyEntries, force))
+      })
+      .flatMap(serialiseFutures(_)(repo => repoLibDepRepository.update(repo)))
   }
+
+
+  def getLatestSbtPluginVersions(sbtPlugins: Seq[SbtPluginConfig]): Seq[SbtPluginVersion] =
+    sbtPlugins.flatMap(github.findLatestSbtPluginVersion)
+
+  def getLatestLibrariesVersions(libraries: Seq[String]): Seq[LibraryVersion] =
+    libraries.flatMap(github.findLatestLibraryVersion)
 
 }

--- a/test/uk/gov/hmrc/servicedependencies/connector/GithubConnectorSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/connector/GithubConnectorSpec.scala
@@ -34,9 +34,7 @@ class GithubConnectorSpec extends WordSpec with MustMatchers with MockitoSugar {
 
   val mockGithub = mock[Github]
 
-  val githubConnector = new GithubConnector(config, metrics) {
-    override lazy val github: Github = mockGithub
-  }
+  val githubConnector = new GithubConnector(mockGithub)
 
 
   "findPluginDependencies" should {

--- a/test/uk/gov/hmrc/servicedependencies/connector/GithubConnectorSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/connector/GithubConnectorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.servicedependencies.connector
 import com.kenshoo.play.metrics.DisabledMetrics
 import org.joda.time.DateTime

--- a/test/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnectorSpec.scala
@@ -89,11 +89,6 @@ class TeamsAndRepositoriesConnectorSpec
   "Retrieving a list of all repositories" - {
     "correctly parse json response" in {
       val repositories = services.getAllRepositories().futureValue
-      repositories mustBe Seq("test-repo", "another-repo")
-    }
-
-    "return a list of full repo objects" in {
-      val repositories = services.getAllRepositoryInfos().futureValue
       repositories mustBe List(
         RepositoryInfo("test-repo", new DateTime("2015-09-15T17:27:38.000+01:00"), new DateTime("2017-05-19T12:00:51.000+01:00"),"Prototype",None),
         RepositoryInfo("another-repo",new DateTime("2016-05-12T11:18:53.000+01:00"), new DateTime("2016-05-12T16:43:32.000+01:00"),"Prototype",None))

--- a/test/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnectorSpec.scala
@@ -23,7 +23,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.Application
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+import scala.concurrent.ExecutionContext.Implicits.global
 import uk.gov.hmrc.servicedependencies.WireMockConfig
 import com.github.tomakehurst.wiremock.client.WireMock._
 import org.joda.time.DateTime

--- a/test/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/connector/TeamsAndRepositoriesConnectorSpec.scala
@@ -26,6 +26,8 @@ import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.servicedependencies.WireMockConfig
 import com.github.tomakehurst.wiremock.client.WireMock._
+import org.joda.time.DateTime
+import uk.gov.hmrc.servicedependencies.connector.model.RepositoryInfo
 
 class TeamsAndRepositoriesConnectorSpec
     extends FreeSpec
@@ -88,6 +90,13 @@ class TeamsAndRepositoriesConnectorSpec
     "correctly parse json response" in {
       val repositories = services.getAllRepositories().futureValue
       repositories mustBe Seq("test-repo", "another-repo")
+    }
+
+    "return a list of full repo objects" in {
+      val repositories = services.getAllRepositoryInfos().futureValue
+      repositories mustBe List(
+        RepositoryInfo("test-repo", new DateTime("2015-09-15T17:27:38.000+01:00"), new DateTime("2017-05-19T12:00:51.000+01:00"),"Prototype",None),
+        RepositoryInfo("another-repo",new DateTime("2016-05-12T11:18:53.000+01:00"), new DateTime("2016-05-12T16:43:32.000+01:00"),"Prototype",None))
     }
   }
 

--- a/test/uk/gov/hmrc/servicedependencies/service/DependenciesDataSourceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/DependenciesDataSourceSpec.scala
@@ -361,9 +361,6 @@ class DependenciesDataSourceSpec
       .thenReturn(Future.successful(Map("service1" -> Seq("PlatOps", "WebOps"))))
 
     when(teamsAndRepositoriesConnector.getAllRepositories()(any()))
-      .thenReturn(Future.successful(repositories.map(_.name)))
-
-    when(teamsAndRepositoriesConnector.getAllRepositoryInfos()(any()))
       .thenReturn(Future.successful(repositories.map(r => RepositoryInfo(r.name, r.lastActive, r.lastActive, "Service"))))
 
     when(teamsAndRepositoriesConnector.getRepository(any())(any())).thenAnswer(new Answer[Future[Option[Repository]]] {

--- a/test/uk/gov/hmrc/servicedependencies/service/DependenciesDataSourceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/DependenciesDataSourceSpec.scala
@@ -381,10 +381,7 @@ class DependenciesDataSourceSpec
         Right(lookupTable(repoName))
     }
 
-    val githubConnector = new GithubConnector(mockedDependenciesConfig, new DisabledMetrics()) {
-      override lazy val github: Github = githubStub()
-      override def now: DateTime       = timeNow
-    }
+    val githubConnector = new GithubConnector(githubStub())
 
     val dependenciesDataSource = new DependenciesDataSource(
       teamsAndRepositoriesConnector,


### PR DESCRIPTION
- Reduced calls to teams-and-repositories API by bringing back the lastActive date in the inital getAll call.
- Moved github functionality out of TeamsAndRepositoriesConnector into GithubConnector.
- Added DI provider for Github API client
