### PR TITLE
BDOG-183 represent BobbyVersionRange as String in Json

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/connector/model/BobbyVersion.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/model/BobbyVersion.scala
@@ -20,10 +20,3 @@ import play.api.libs.json.{OWrites, __}
 import uk.gov.hmrc.servicedependencies.model.Version
 
 final case class BobbyVersion(version: Version, inclusive: Boolean)
-
-object BobbyVersion {
-  val writes: OWrites[BobbyVersion] =
-    ( (__ \ "version"  ).write[Version](Version.legacyApiWrites)
-    ~ (__ \ "inclusive").write[Boolean]
-    )(unlift(BobbyVersion.unapply))
-}

--- a/app/uk/gov/hmrc/servicedependencies/connector/model/BobbyVersionRange.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/model/BobbyVersionRange.scala
@@ -47,8 +47,6 @@ object BobbyVersionRange {
   private val rangeRegex = """^[\[\(](\d+\.\d+.\d+),(\d+\.\d+.\d+)[\]\)]""".r
   private val qualifier  = """^\[[-\*]+(.*)\]""".r
 
-  val reads: Reads[BobbyVersionRange] = JsPath.read[String].map(BobbyVersionRange.apply)
-
   def apply(range: String): BobbyVersionRange = {
     val trimmedRange = range.replaceAll(" ", "")
 
@@ -81,4 +79,9 @@ object BobbyVersionRange {
     }
   }
 
+  val reads: Reads[BobbyVersionRange] =
+    JsPath.read[String].map(BobbyVersionRange.apply)
+
+  val writes: Writes[BobbyVersionRange] =
+    Writes(bvr => JsString(bvr.range))
 }

--- a/app/uk/gov/hmrc/servicedependencies/controller/model/DependencyBobbyRule.scala
+++ b/app/uk/gov/hmrc/servicedependencies/controller/model/DependencyBobbyRule.scala
@@ -30,16 +30,11 @@ case class DependencyBobbyRule(
 
 object DependencyBobbyRule {
 
-  private val writesBobbyVersionRange: OWrites[BobbyVersionRange] =
-    ( (__ \ "lowerBound").writeNullable[BobbyVersion](BobbyVersion.writes)
-    ~ (__ \ "upperBound").writeNullable[BobbyVersion](BobbyVersion.writes)
-    ~ (__ \ "qualifier" ).writeNullable[String]
-    ~ (__ \ "range"     ).write[String]
-    )(unlift(BobbyVersionRange.unapply))
-
-  val writes: OWrites[DependencyBobbyRule] =
+  val writes: OWrites[DependencyBobbyRule] = {
+    implicit val bvrw = BobbyVersionRange.writes
     ( (__ \ "reason").write[String]
     ~ (__ \ "from"  ).write[LocalDate]
-    ~ (__ \ "range" ).write[BobbyVersionRange](writesBobbyVersionRange)
+    ~ (__ \ "range" ).write[BobbyVersionRange]
     )(unlift(DependencyBobbyRule.unapply))
+  }
 }


### PR DESCRIPTION
Simplified payload since current client (catalogue-frontend) has to parse Bobby version range strings anyway (it consumes version ranges from service-configs). It avoids trying to guess what client will do with the data.