### PR TITLE
BDOG-212: Add endpoint for persisting slug info

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/SlugJobCreatorScheduler.scala
+++ b/app/uk/gov/hmrc/servicedependencies/SlugJobCreatorScheduler.scala
@@ -22,8 +22,8 @@ import play.api.Logger
 import play.api.inject.ApplicationLifecycle
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.servicedependencies.config.SchedulerConfigs
-import uk.gov.hmrc.servicedependencies.service.{SlugInfoService, SlugJobCreator, SlugJobProcessor}
 import uk.gov.hmrc.servicedependencies.persistence.MongoLocks
+import uk.gov.hmrc.servicedependencies.service.{SlugInfoService, SlugJobCreator, SlugJobProcessor}
 import uk.gov.hmrc.servicedependencies.util.SchedulerUtils
 
 import scala.concurrent.ExecutionContext
@@ -42,16 +42,11 @@ class SlugJobCreatorScheduler @Inject()(
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
   import ExecutionContext.Implicits.global
-/*
+
   scheduleWithLock("Slug Info Reloader", schedulerConfigs.slugJobCreator, mongoLocks.slugJobSchedulerLock) {
-    for {
-      _ <- slugJobCreator.run
-      _ = Logger.info("Finished creating slug jobs - now processing jobs")
-      _ <- slugJobProcessor.run
-      _ = Logger.info("Finished processing slug jobs - now updating meta data")
-      _ <- slugInfoService.updateMetaData
-      _ = Logger.info("Finished updating meta data")
-    } yield ()
-  }*/
+    Logger.info("Updating metadata")
+    slugInfoService.updateMetadata
+      .map(_ => Logger.info("Finished updating metadata"))
+  }
 
 }

--- a/app/uk/gov/hmrc/servicedependencies/SlugJobCreatorScheduler.scala
+++ b/app/uk/gov/hmrc/servicedependencies/SlugJobCreatorScheduler.scala
@@ -42,9 +42,12 @@ class SlugJobCreatorScheduler @Inject()(
   import ExecutionContext.Implicits.global
 
   scheduleWithLock("Slug Info Reloader", schedulerConfigs.slugJobCreator, mongoLocks.slugJobSchedulerLock) {
-    Logger.info("Updating metadata")
-    slugInfoService.updateMetadata
-      .map(_ => Logger.info("Finished updating metadata"))
-  }
 
+    Logger.info("Updating metadata")
+    for {
+      _ <- slugInfoService.updateMetadata
+      _ = Logger.info("Finished updating metadata")
+    } yield ()
+
+  }
 }

--- a/app/uk/gov/hmrc/servicedependencies/SlugJobCreatorScheduler.scala
+++ b/app/uk/gov/hmrc/servicedependencies/SlugJobCreatorScheduler.scala
@@ -40,16 +40,18 @@ class SlugJobCreatorScheduler @Inject()(
   extends SchedulerUtils {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
-  import ExecutionContext.Implicits.global
 
+  import ExecutionContext.Implicits.global
+/*
   scheduleWithLock("Slug Info Reloader", schedulerConfigs.slugJobCreator, mongoLocks.slugJobSchedulerLock) {
     for {
       _ <- slugJobCreator.run
-      _ =  Logger.info("Finished creating slug jobs - now processing jobs")
+      _ = Logger.info("Finished creating slug jobs - now processing jobs")
       _ <- slugJobProcessor.run
-      _ =  Logger.info("Finished processing slug jobs - now updating meta data")
+      _ = Logger.info("Finished processing slug jobs - now updating meta data")
       _ <- slugInfoService.updateMetaData
-      _ =  Logger.info("Finished updating meta data")
-      } yield ()
-  }
+      _ = Logger.info("Finished updating meta data")
+    } yield ()
+  }*/
+
 }

--- a/app/uk/gov/hmrc/servicedependencies/SlugJobCreatorScheduler.scala
+++ b/app/uk/gov/hmrc/servicedependencies/SlugJobCreatorScheduler.scala
@@ -23,7 +23,7 @@ import play.api.inject.ApplicationLifecycle
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.servicedependencies.config.SchedulerConfigs
 import uk.gov.hmrc.servicedependencies.persistence.MongoLocks
-import uk.gov.hmrc.servicedependencies.service.{SlugInfoService, SlugJobCreator, SlugJobProcessor}
+import uk.gov.hmrc.servicedependencies.service.SlugInfoService
 import uk.gov.hmrc.servicedependencies.util.SchedulerUtils
 
 import scala.concurrent.ExecutionContext
@@ -31,8 +31,6 @@ import scala.concurrent.ExecutionContext
 
 class SlugJobCreatorScheduler @Inject()(
     schedulerConfigs    : SchedulerConfigs,
-    slugJobCreator      : SlugJobCreator,
-    slugJobProcessor    : SlugJobProcessor,
     slugInfoService     : SlugInfoService,
     mongoLocks          : MongoLocks)(
     implicit actorSystem         : ActorSystem,

--- a/app/uk/gov/hmrc/servicedependencies/connector/GzippedResourceConnector.scala
+++ b/app/uk/gov/hmrc/servicedependencies/connector/GzippedResourceConnector.scala
@@ -20,12 +20,13 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Compression, StreamConverters}
 import java.io.InputStream
+
 import javax.inject.Inject
 import play.api.Logger
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{Duration, DurationInt}
 
 
 class GzippedResourceConnector @Inject()(
@@ -41,8 +42,8 @@ class GzippedResourceConnector @Inject()(
 
     import ExecutionContext.Implicits.global
 
-    ws.url(resourceUrl).withMethod("GET").stream.map { resp =>
-      resp.bodyAsSource.async.via(Compression.gunzip()).runWith(StreamConverters.asInputStream(readTimeout = 20.seconds))
+    ws.url(resourceUrl).withMethod("GET").withRequestTimeout(Duration.Inf).stream.map { resp =>
+      resp.bodyAsSource.async.via(Compression.gunzip()).runWith(StreamConverters.asInputStream(readTimeout = 20.hour))
     }
   }
 }

--- a/app/uk/gov/hmrc/servicedependencies/controller/admin/ServiceMetaController.scala
+++ b/app/uk/gov/hmrc/servicedependencies/controller/admin/ServiceMetaController.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.servicedependencies.controller.admin
+
+import com.google.inject.{Inject, Singleton}
+import play.api.Logger
+import play.api.libs.json.{JsError, Reads}
+import play.api.mvc.ControllerComponents
+import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.servicedependencies.model.{ApiSlugInfoFormats, SlugInfo}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+@Singleton
+class ServiceMetaController @Inject()(cc: ControllerComponents)
+                                     (implicit ec: ExecutionContext)
+extends BackendController(cc) {
+
+  implicit val slugInfoFormat = ApiSlugInfoFormats.siFormat
+
+  private def validateJson[A: Reads] =
+    parse.json.validate(
+      _.validate[A].asEither.left.map(e => BadRequest(JsError.toJson(e)))
+    )
+
+  def setSlugInfo =
+    Action.async(validateJson[SlugInfo]) { implicit request =>
+      Future.successful(logSlugInfo(request.body))
+        .map(_ => Ok("Done"))
+    }
+
+  private def logSlugInfo(slugInfo: SlugInfo) = {
+    Logger.info(s"Setting slug data: ${slugInfo.name} ${slugInfo.version.original}")
+    true
+  }
+
+}

--- a/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
@@ -19,10 +19,9 @@ package uk.gov.hmrc.servicedependencies.service
 import cats.instances.all._
 import cats.syntax.all._
 import com.google.inject.{Inject, Singleton}
-import play.api.Logger
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.servicedependencies.connector.{ServiceDeploymentsConnector, TeamsAndRepositoriesConnector}
 import uk.gov.hmrc.servicedependencies.connector.model.BobbyVersionRange
+import uk.gov.hmrc.servicedependencies.connector.{ServiceDeploymentsConnector, TeamsAndRepositoriesConnector}
 import uk.gov.hmrc.servicedependencies.model._
 import uk.gov.hmrc.servicedependencies.persistence.{DependencyConfigRepository, SlugInfoRepository, SlugParserJobsRepository}
 
@@ -38,22 +37,11 @@ class SlugInfoService @Inject()(
 ) {
   import ExecutionContext.Implicits.global
 
-  def addSlugInfo(slug: SlugInfo): Future[Boolean] = {
-    Logger.info(s"Setting slug data: ${slug.name} ${slug.version.original}")
+  def addSlugInfo(slug: SlugInfo): Future[Boolean] =
     for {
-      added <- slugInfoRepository.add(slug)
-      isLatest <- slugInfoRepository.getSlugInfos(name = slug.name, optVersion = None).map {
-        case Nil => true
-        case nonempty => val isLatest = nonempty.map(_.version).max == slug.version
-          Logger.info(s"Slug ${slug.name} ${slug.version} isLatest=$isLatest (out of: ${nonempty.map(_.version).sorted})")
-          isLatest
-      }
-      _ <- if (isLatest) slugInfoRepository.markLatest(slug.name, slug.version)
-      else Future(())
-      _ = if (added) Logger.debug(s"added slugInfo for ${slug.uri}: ${slug.name} ${slug.version}")
-      else Logger.warn(s"slug ${slug.uri} not added - already processed")
+      added     <- slugInfoRepository.add(slug)
+      _         <- if (slug.latest) slugInfoRepository.markLatest(slug.name, slug.version) else Future(())
     } yield added
-  }
 
   def addSlugParserJob(newJob: NewSlugParserJob): Future[Boolean] =
     slugParserJobsRepository.add(newJob)
@@ -82,7 +70,8 @@ class SlugInfoService @Inject()(
     slugInfoRepository
       .findGroupsArtefacts
 
-  def updateMetaData(implicit hc: HeaderCarrier): Future[Unit] = {
+  def updateMetadata(implicit hc: HeaderCarrier): Future[Unit] = {
+
     import ServiceDeploymentsConnector._
     for {
       serviceNames           <- slugInfoRepository.getUniqueSlugNames

--- a/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.servicedependencies.service
 import cats.instances.all._
 import cats.syntax.all._
 import com.google.inject.{Inject, Singleton}
-import org.slf4j.LoggerFactory
+import play.api.Logger
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.servicedependencies.connector.{ServiceDeploymentsConnector, TeamsAndRepositoriesConnector}
 import uk.gov.hmrc.servicedependencies.connector.model.BobbyVersionRange
@@ -38,7 +38,22 @@ class SlugInfoService @Inject()(
 ) {
   import ExecutionContext.Implicits.global
 
-  lazy val logger = LoggerFactory.getLogger(this.getClass)
+  def addSlugInfo(slug: SlugInfo): Future[Boolean] = {
+    Logger.info(s"Setting slug data: ${slug.name} ${slug.version.original}")
+    for {
+      added <- slugInfoRepository.add(slug)
+      isLatest <- slugInfoRepository.getSlugInfos(name = slug.name, optVersion = None).map {
+        case Nil => true
+        case nonempty => val isLatest = nonempty.map(_.version).max == slug.version
+          Logger.info(s"Slug ${slug.name} ${slug.version} isLatest=$isLatest (out of: ${nonempty.map(_.version).sorted})")
+          isLatest
+      }
+      _ <- if (isLatest) slugInfoRepository.markLatest(slug.name, slug.version)
+      else Future(())
+      _ = if (added) Logger.debug(s"added slugInfo for ${slug.uri}: ${slug.name} ${slug.version}")
+      else Logger.warn(s"slug ${slug.uri} not added - already processed")
+    } yield added
+  }
 
   def addSlugParserJob(newJob: NewSlugParserJob): Future[Boolean] =
     slugParserJobsRepository.add(newJob)

--- a/conf/admin.routes
+++ b/conf/admin.routes
@@ -9,4 +9,4 @@ GET     /mongo-locks                        @uk.gov.hmrc.servicedependencies.con
 POST    /slug-parser-jobs/backfill          @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.backfillSlugParserJobs
 POST    /slug-parser-jobs/process           @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.processSlugParserJobs
 
-POST    /slugs                              @uk.gov.hmrc.servicedependencies.controller.admin.ServiceMetaController.setSlugInfo
+POST    /slugs                              @uk.gov.hmrc.servicedependencies.controller.admin.ServiceMetaController.setSlugInfo()

--- a/conf/admin.routes
+++ b/conf/admin.routes
@@ -1,8 +1,12 @@
 GET     /reload-library-versions            @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.reloadLibraryVersions()
 GET     /reload-sbt-plugin-versions         @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.reloadSbtPluginVersions()
 GET     /reload-dependencies                @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.reloadLibraryDependenciesForAllRepositories(force: Option[Boolean])
+
 POST    /drop-collection/:collection        @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.dropCollection(collection)
 POST    /clear-update-dates                 @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.clearUpdateDates
 GET     /mongo-locks                        @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.mongoLocks()
+
 POST    /slug-parser-jobs/backfill          @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.backfillSlugParserJobs
 POST    /slug-parser-jobs/process           @uk.gov.hmrc.servicedependencies.controller.admin.AdministrationController.processSlugParserJobs
+
+POST    /slugs                              @uk.gov.hmrc.servicedependencies.controller.admin.ServiceMetaController.setSlugInfo

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -150,7 +150,7 @@ repositoryDependencies.metricsGauges.interval     = 10 minutes
 repositoryDependencies.metricsGauges.initialDelay = 1 minute
 
 repositoryDependencies.slugJob.enabled      = false
-repositoryDependencies.slugJob.interval     = 30 minutes
+repositoryDependencies.slugJob.interval     = 5 minutes
 repositoryDependencies.slugJob.initialDelay = 1 minute
 
 mongodb {
@@ -159,5 +159,5 @@ mongodb {
 
 curated.config.path = "/dependency-versions-config.json"
 
-artifactory.url = "https://change.this.to.artifactory.url/artifactory"
-artifactory.webstore = "http://change-this-to-webstore"
+artifactory.url = "https://artefacts.tax.service.gov.uk/artifactory"
+artifactory.webstore = "https://webstore.tax.service.gov.uk"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -87,6 +87,11 @@ controllers {
     needsAuditing = false
   }
 
+  uk.gov.hmrc.servicedependencies.ServiceMetaController = {
+    needsAuth = false
+    needsLogging = false
+    needsAuditing = false
+  }
 }
 
 
@@ -149,8 +154,8 @@ repositoryDependencies.metricsGauges.enabled      = false
 repositoryDependencies.metricsGauges.interval     = 10 minutes
 repositoryDependencies.metricsGauges.initialDelay = 1 minute
 
-repositoryDependencies.slugJob.enabled      = false
-repositoryDependencies.slugJob.interval     = 5 minutes
+repositoryDependencies.slugJob.enabled      = true
+repositoryDependencies.slugJob.interval     = 10 minutes
 repositoryDependencies.slugJob.initialDelay = 1 minute
 
 mongodb {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -164,5 +164,5 @@ mongodb {
 
 curated.config.path = "/dependency-versions-config.json"
 
-artifactory.url = "https://artefacts.tax.service.gov.uk/artifactory"
-artifactory.webstore = "https://webstore.tax.service.gov.uk"
+artifactory.url = "https://change.this.to.artifactory.url/artifactory"
+artifactory.webstore = "http://change-this-to-webstore"


### PR DESCRIPTION
This PR adds an endpoint for use by artefact-processor to persist slug info to service-dependencies.