### PR TITLE
BDOG-446 add endpoint for curated slug dependencies

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/service/ServiceConfigsService.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/ServiceConfigsService.scala
@@ -14,27 +14,11 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2019 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package uk.gov.hmrc.servicedependencies.service
 
 import com.google.inject.{Inject, Singleton}
 import uk.gov.hmrc.servicedependencies.connector.ServiceConfigsConnector
-import uk.gov.hmrc.servicedependencies.controller.model.{Dependencies, Dependency}
+import uk.gov.hmrc.servicedependencies.controller.model.{Dependencies, Dependency, DependencyBobbyRule}
 import uk.gov.hmrc.servicedependencies.model.BobbyRule
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -42,24 +26,39 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class ServiceConfigsService @Inject()(serviceConfigsConnector: ServiceConfigsConnector)(implicit ec: ExecutionContext) {
 
+  import ServiceConfigsService._
+
   def getDependenciesWithBobbyRules(dependencies: Dependencies): Future[Dependencies] =
-    serviceConfigsConnector
-      .getBobbyRules()
-      .map { groupedDeps =>
+    serviceConfigsConnector.getBobbyRules().map { bobbyRules =>
+      val addViolations = enrichWithBobbyRuleViolations(bobbyRules) _
+      dependencies.copy(
+        libraryDependencies = dependencies.libraryDependencies.map(addViolations),
+        sbtPluginsDependencies = dependencies.sbtPluginsDependencies.map(addViolations),
+        otherDependencies      = dependencies.otherDependencies.map(addViolations)
+      )
+    }
 
-        def addBobbyViolations(dependency: Dependency): Dependency =
-            dependency.copy(bobbyRuleViolations =
-              groupedDeps
-                .getOrElse(s"${dependency.name}", List())
-                .filter(_.range.includes(dependency.currentVersion))
-                .map(_.asDependencyBobbyRule)
-            )
-
-        dependencies
-          .copy(
-              libraryDependencies    = dependencies.libraryDependencies.map(addBobbyViolations)
-            , sbtPluginsDependencies = dependencies.sbtPluginsDependencies.map(addBobbyViolations)
-            , otherDependencies      = dependencies.otherDependencies.map(addBobbyViolations)
-            )
+  /*
+   * For consistency with above - but would prefer to simply return a mapping of dependency to violations.
+   */
+  def getDependenciesWithBobbyRules(dependencies: List[Dependency]): Future[List[Dependency]] =
+    serviceConfigsConnector.getBobbyRules().map { bobbyRules =>
+      dependencies.map {
+        enrichWithBobbyRuleViolations(bobbyRules)(_)
       }
+    }
+}
+
+private object ServiceConfigsService {
+  def enrichWithBobbyRuleViolations(bobbyRules: Map[String, List[BobbyRule]])(dependency: Dependency): Dependency =
+    dependency.copy(
+      bobbyRuleViolations = bobbyRuleViolationsFor(bobbyRules)(dependency)
+    )
+
+  def bobbyRuleViolationsFor(bobbyRules: Map[String, List[BobbyRule]])
+                            (dependency: Dependency): List[DependencyBobbyRule] =
+    bobbyRules.
+      getOrElse(dependency.name, Nil).
+      filter(_.range.includes(dependency.currentVersion)).
+      map(_.asDependencyBobbyRule)
 }

--- a/app/uk/gov/hmrc/servicedependencies/service/SlugDependenciesService.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/SlugDependenciesService.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.servicedependencies.service
+
+import javax.inject.{Inject, Singleton}
+import uk.gov.hmrc.servicedependencies.config.CuratedDependencyConfigProvider
+import uk.gov.hmrc.servicedependencies.controller.model.Dependency
+import uk.gov.hmrc.servicedependencies.model.{MongoLibraryVersion, SlugDependency, SlugInfo, Version}
+import uk.gov.hmrc.servicedependencies.persistence.{LibraryVersionRepository, SlugInfoRepository}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+@Singleton
+class SlugDependenciesService @Inject() (slugInfoRepository: SlugInfoRepository,
+                                         curatedDependencyConfigProvider: CuratedDependencyConfigProvider,
+                                         libraryVersionRepository: LibraryVersionRepository,
+                                         serviceConfigsService: ServiceConfigsService) {
+
+  private lazy val curatedLibraries = curatedDependencyConfigProvider.curatedDependencyConfig.libraries.toSet
+
+  /*
+   * We may want to evolve the model - but for this initial version we reuse the existing Dependency definition.
+   */
+  def curatedLibrariesOfSlug(name: String, version: String): Future[Option[List[Dependency]]] = {
+    val futLatestVersionByName = libraryVersionRepository.getAllEntries.map(toLatestVersionByName)
+    val futOptCuratedDependencies = slugInfoRepository.getSlugInfos(name, Some(version)).map(toCuratedDependencies)
+
+    futLatestVersionByName.flatMap { latestVersionByName =>
+      val asDependency = toDependency(latestVersionByName.get) _
+      futOptCuratedDependencies.flatMap {
+        case None => Future.successful(None)
+        case Some(slugDependencies) =>
+          val dependencies = slugDependencies.map(asDependency)
+          serviceConfigsService.getDependenciesWithBobbyRules(dependencies).map(Some(_))
+      }
+    }
+  }
+
+  private def toLatestVersionByName(latestVersions: Seq[MongoLibraryVersion]): Map[String, Version] =
+    latestVersions.flatMap { library =>
+      library.version.map {
+        library.libraryName -> _
+      }
+    }.toMap
+
+  private def toCuratedDependencies(slugInfos: Seq[SlugInfo]): Option[List[SlugDependency]] =
+    slugInfos.headOption.map {
+      _.dependencies.filter(slugDependency => curatedLibraries.contains(slugDependency.artifact))
+    }
+
+  private type VersionLookup = String => Option[Version]
+
+  private def toDependency(latestVersionLookup: VersionLookup)(slugDependency: SlugDependency): Dependency =
+    Dependency(
+      name = slugDependency.artifact,
+      currentVersion = Version(slugDependency.version),  // TODO this is unsafe
+      latestVersion = latestVersionLookup(slugDependency.artifact),
+      bobbyRuleViolations = Nil
+    )
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,3 +8,4 @@ GET     /api/groupArtefacts                    @uk.gov.hmrc.servicedependencies.
 GET     /api/jdkVersions                       @uk.gov.hmrc.servicedependencies.controller.ServiceDependenciesController.findJDKForEnvironment(flag: String ?= "latest")
 GET     /api/bobbyViolations                   @uk.gov.hmrc.servicedependencies.controller.BobbyRuleViolationController.findBobbyRuleViolations
 GET     /api/historicBobbyViolations           @uk.gov.hmrc.servicedependencies.controller.BobbyRuleViolationController.findHistoricBobbyRuleViolations
+GET     /api/slug-dependencies/:name/:version  @uk.gov.hmrc.servicedependencies.controller.ServiceDependenciesController.dependenciesOfSlug(name, version)

--- a/test/uk/gov/hmrc/servicedependencies/persistence/RepositoryLibraryDependenciesRepositorySpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/persistence/RepositoryLibraryDependenciesRepositorySpec.scala
@@ -42,6 +42,8 @@ import uk.gov.hmrc.mongo.test.CleanMongoCollectionSupport
 import uk.gov.hmrc.servicedependencies.model.{MongoRepositoryDependencies, MongoRepositoryDependency, Version}
 import uk.gov.hmrc.servicedependencies.util.{FutureHelpers, MockFutureHelpers}
 
+import scala.concurrent.duration._
+
 class RepositoryLibraryDependenciesRepositorySpec
     extends WordSpecLike
       with Matchers
@@ -52,6 +54,7 @@ class RepositoryLibraryDependenciesRepositorySpec
   val futureHelper: FutureHelpers = new MockFutureHelpers()
   val repo = new RepositoryLibraryDependenciesRepository(mongoComponent, futureHelper)
 
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 30.seconds, interval = 100.millis)
   override protected val collectionName: String   = repo.collectionName
   override protected val indexes: Seq[IndexModel] = repo.indexes
 

--- a/test/uk/gov/hmrc/servicedependencies/service/SlugDependenciesServiceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/SlugDependenciesServiceSpec.scala
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.servicedependencies.service
+
+import java.time.{LocalDate, LocalDateTime}
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.servicedependencies.config.CuratedDependencyConfigProvider
+import uk.gov.hmrc.servicedependencies.config.model.CuratedDependencyConfig
+import uk.gov.hmrc.servicedependencies.controller.model.{Dependency, DependencyBobbyRule}
+import uk.gov.hmrc.servicedependencies.model._
+import uk.gov.hmrc.servicedependencies.persistence.{LibraryVersionRepository, SlugInfoRepository}
+
+import scala.concurrent.Future
+
+class SlugDependenciesServiceSpec extends FreeSpec with MockitoSugar with Matchers with ScalaFutures with OptionValues {
+
+  import SlugDependenciesServiceSpec._
+
+  private trait Fixture {
+    val slugInfoRepository = mock[SlugInfoRepository]
+    val curatedDependencyConfigProvider = mock[CuratedDependencyConfigProvider]
+    val libraryVersionRepository = mock[LibraryVersionRepository]
+    val serviceConfigsService = mock[ServiceConfigsService]
+
+    val underTest = new SlugDependenciesService(slugInfoRepository, curatedDependencyConfigProvider,
+      libraryVersionRepository, serviceConfigsService)
+
+    def stubCuratedLibrariesOf(libraryNames: String*): Unit =
+      when(curatedDependencyConfigProvider.curatedDependencyConfig).thenReturn(
+        aCuratedDependencyConfig(libraryNames)
+      )
+
+    def stubLatestLibraryVersionsOf(nameToVersionMapping: (String, Version)*): Unit =
+      when(libraryVersionRepository.getAllEntries).thenReturn(
+        Future.successful(
+          nameToVersionMapping.map { case (n, v) =>
+            MongoLibraryVersion(libraryName = n, version = Some(v))
+          }
+        )
+      )
+
+    def stubBobbyRulesViolations(dependencies: List[Dependency], violations: List[List[DependencyBobbyRule]]): Unit = {
+      val enrichedDependencies = dependencies.zip(violations).map { case (dependency, violations) =>
+        dependency.copy(bobbyRuleViolations = violations)
+      }
+
+      when(serviceConfigsService.getDependenciesWithBobbyRules(dependencies)).thenReturn(
+        Future.successful(enrichedDependencies)
+      )
+    }
+
+    def stubNoBobbyRulesViolations(): Unit = {
+      val withArgumentAsFutureSuccess = new Answer[Future[List[Dependency]]] {
+        private val ArgIndex = 0
+        override def answer(invocation: InvocationOnMock): Future[List[Dependency]] = {
+          val dependencies = invocation.getArgument[List[Dependency]](ArgIndex)
+          Future.successful(dependencies)
+        }
+      }
+
+      when(serviceConfigsService.getDependenciesWithBobbyRules(any[List[Dependency]]())).thenAnswer(withArgumentAsFutureSuccess)
+    }
+  }
+
+  "SlugDependenciesService" - {
+
+    "retrieves only the dependencies of a known slug that are curated dependencies" - {
+      "enriched with bobby rules violations" in new Fixture {
+        val dependency1PreViolationEnrichment = Dependency(name = Dependency1.artifact,
+          currentVersion = Version(Dependency1.version), latestVersion = None, bobbyRuleViolations = Nil)
+        val dependency3PreViolationEnrichment = Dependency(name = Dependency3.artifact,
+          currentVersion = Version(Dependency3.version), latestVersion = None, bobbyRuleViolations = Nil)
+        val dependency1RuleViolation = DependencyBobbyRule(reason = "some reason", from = LocalDate.now(), range = BobbyVersionRange("(,9.9.9)"))
+        stubBobbyRulesViolations(
+          dependencies = List(dependency1PreViolationEnrichment, dependency3PreViolationEnrichment),
+          violations = List(List(dependency1RuleViolation), Nil)
+        )
+        stubLatestLibraryVersionsOf()
+        stubCuratedLibrariesOf(Dependency1.artifact, Dependency3.artifact)
+        when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
+          Future.successful(Seq(slugInfo(withName = SlugName, withVersion = SlugVersion,
+            withDependencies = List(Dependency1, Dependency2, Dependency3))
+          ))
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).futureValue.value should contain theSameElementsAs Seq(
+          dependency1PreViolationEnrichment.copy(bobbyRuleViolations = List(dependency1RuleViolation)),
+          dependency3PreViolationEnrichment
+        )
+      }
+
+      "enriched with latest versions when known" in new Fixture {
+        stubNoBobbyRulesViolations()
+        stubLatestLibraryVersionsOf(Dependency1.artifact -> LatestVersionOfDependency1, Dependency3.artifact -> LatestVersionOfDependency3)
+        stubCuratedLibrariesOf(Dependency1.artifact, Dependency3.artifact)
+        when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
+          Future.successful(Seq(slugInfo(withName = SlugName, withVersion = SlugVersion,
+            withDependencies = List(Dependency1, Dependency2, Dependency3))
+          ))
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).futureValue.value should contain theSameElementsAs Seq(
+          Dependency(name = Dependency1.artifact, currentVersion = Version(Dependency1.version), latestVersion = Some(LatestVersionOfDependency1), bobbyRuleViolations = Nil),
+          Dependency(name = Dependency3.artifact, currentVersion = Version(Dependency3.version), latestVersion = Some(LatestVersionOfDependency3), bobbyRuleViolations = Nil)
+        )
+      }
+
+      "without latest versions when not known" in new Fixture {
+        stubNoBobbyRulesViolations()
+        stubLatestLibraryVersionsOf()
+        stubCuratedLibrariesOf(Dependency1.artifact, Dependency3.artifact)
+        when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
+          Future.successful(Seq(slugInfo(withName = SlugName, withVersion = SlugVersion,
+            withDependencies = List(Dependency1, Dependency2, Dependency3))
+          ))
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).futureValue.value should contain theSameElementsAs Seq(
+          Dependency(name = Dependency1.artifact, currentVersion = Version(Dependency1.version), latestVersion = None, bobbyRuleViolations = Nil),
+          Dependency(name = Dependency3.artifact, currentVersion = Version(Dependency3.version), latestVersion = None, bobbyRuleViolations = Nil)
+        )
+      }
+    }
+
+    "indicates that the requested slug could not be found by returning None" in new Fixture {
+      stubLatestLibraryVersionsOf()
+      when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
+        Future.successful(Seq.empty)
+      )
+
+      underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).futureValue shouldBe None
+    }
+
+    "propagates any failure to retrieve the latest versions of libraries" in new Fixture {
+      val failure = new RuntimeException("failed to retrieve latest library versions")
+      when(libraryVersionRepository.getAllEntries).thenReturn(
+        Future.failed(failure)
+      )
+      when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
+        Future.successful(Seq.empty)
+      )
+
+      underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).failed.futureValue shouldBe failure
+    }
+
+    "propagates any failure to retrieve slug infos" in new Fixture {
+      val failure = new RuntimeException("failed to retrieve slug infos")
+      stubLatestLibraryVersionsOf()
+      when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
+        Future.failed(failure)
+      )
+
+      underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).failed.futureValue shouldBe failure
+    }
+
+    "propagates any failure to determine bobby rule violations" in new Fixture {
+      stubLatestLibraryVersionsOf()
+      when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
+        Future.successful(Seq(slugInfo(withName = SlugName, withVersion = SlugVersion,
+          withDependencies = List(Dependency1, Dependency2, Dependency3))
+        ))
+      )
+      stubCuratedLibrariesOf(Dependency1.artifact, Dependency3.artifact)
+      val failure = new RuntimeException("failed to apply bobby rules")
+      when(serviceConfigsService.getDependenciesWithBobbyRules(any[List[Dependency]])).thenReturn(
+        Future.failed(failure)
+      )
+
+      underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).failed.futureValue shouldBe failure
+    }
+  }
+}
+
+private object SlugDependenciesServiceSpec {
+  val SlugName = ""
+  val SlugVersion = "1.2.3"
+  val Dependency1 = SlugDependency(path = "/path/dep1", version = "1.1.1", group = "com.test.group", artifact = "artifact1")
+  val Dependency2 = SlugDependency(path = "/path/dep2", version = "2.2.2", group = "com.test.group", artifact = "artifact2")
+  val Dependency3 = SlugDependency(path = "/path/dep3", version = "3.3.3", group = "com.test.group", artifact = "artifact3")
+  val LatestVersionOfDependency1 = Version("1.2.0")
+  val LatestVersionOfDependency3 = Version("3.4.0")
+
+  def slugInfo(withName: String, withVersion: String, withDependencies: List[SlugDependency]): SlugInfo =
+    SlugInfo(
+      uri = "some-uri",
+      created = LocalDateTime.now(),
+      withName,
+      Version(withVersion),
+      teams = Nil,
+      runnerVersion = "some-runner-version",
+      classpath = "some-classpath",
+      java = JavaInfo("some-java-version", "some-java-vendor", "some-java-kind"),
+      dependencies = withDependencies,
+      applicationConfig = "some-application-config",
+      slugConfig = "some-slug-config",
+      latest = false,
+      production = true,
+      qa = false,
+      staging = true,
+      development = false,
+      externalTest = false,
+      integration = false
+    )
+
+  def aCuratedDependencyConfig(withLibraries: Seq[String]): CuratedDependencyConfig =
+    CuratedDependencyConfig(
+      sbtPlugins = Seq.empty,
+      withLibraries,
+      otherDependencies = Seq.empty
+    )
+}


### PR DESCRIPTION
Provides a new endpoint (`/api/slug-dependencies/:name/:version`) that exposes the dependencies of a slug.

In contrast to the `List[SlugDependency]` that is exposed from a `SlugInfo`, this endpoint re-uses the `Dependency` model to provide enriched dependency information.  In particular, a dependency is enriched with:
* the version number of the latest available version of the dependency
* any Bobby rule violations associated with the dependency

In addition, rather than exposing all dependencies of a slug, only curated platform dependencies are exposed - where 'curated dependencies' are defined by the existing json resource file.