### PR TITLE
BDOG-525: retrieve slug library dependencies for latest when no version is specified

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/persistence/SlugInfoRepositoryBase.scala
+++ b/app/uk/gov/hmrc/servicedependencies/persistence/SlugInfoRepositoryBase.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.servicedependencies.persistence
 
 import com.google.inject.{Inject, Singleton}
-import org.mongodb.scala.model.Indexes.{ascending, hashed}
+import org.mongodb.scala.model.Indexes.{ascending, compoundIndex, descending, hashed}
 import org.mongodb.scala.model.{IndexModel, IndexOptions}
 import play.api.Logger
 import play.api.libs.json.Format
@@ -36,7 +36,11 @@ abstract class SlugInfoRepositoryBase[A: ClassTag] @Inject()(mongo: MongoCompone
       indexes = Seq(
         IndexModel(ascending("uri"), IndexOptions().name("slugInfoUniqueIdx").unique(true)),
         IndexModel(hashed("name"), IndexOptions().name("slugInfoIdx").background(true)),
-        IndexModel(hashed("latest"), IndexOptions().name("slugInfoLatestIdx").background(true))
+        IndexModel(hashed("latest"), IndexOptions().name("slugInfoLatestIdx").background(true)),
+        IndexModel(compoundIndex(ascending("name"), descending("version")),
+          IndexOptions().name("slugInfoNameVersionIdx").background(true)),
+        IndexModel(compoundIndex(ascending("name"), descending("latest")),
+          IndexOptions().name("slugInfoNameLatestIdx").background(true))
       )
     ) {
 

--- a/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
@@ -49,6 +49,9 @@ class SlugInfoService @Inject()(
   def getSlugInfo(name: String, flag: SlugInfoFlag): Future[Option[SlugInfo]] =
     slugInfoRepository.getSlugInfo(name, flag)
 
+  def getSlugInfo(name: String, version: String): Future[Option[SlugInfo]] =
+    slugInfoRepository.getSlugInfos(name, Some(version)).map(_.headOption)
+
   def findServicesWithDependency(
       flag        : SlugInfoFlag
     , group       : String

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,4 +8,4 @@ GET     /api/groupArtefacts                    @uk.gov.hmrc.servicedependencies.
 GET     /api/jdkVersions                       @uk.gov.hmrc.servicedependencies.controller.ServiceDependenciesController.findJDKForEnvironment(flag: String ?= "latest")
 GET     /api/bobbyViolations                   @uk.gov.hmrc.servicedependencies.controller.BobbyRuleViolationController.findBobbyRuleViolations
 GET     /api/historicBobbyViolations           @uk.gov.hmrc.servicedependencies.controller.BobbyRuleViolationController.findHistoricBobbyRuleViolations
-GET     /api/slug-dependencies/:name/:version  @uk.gov.hmrc.servicedependencies.controller.ServiceDependenciesController.dependenciesOfSlug(name, version)
+GET     /api/slug-dependencies/:name           @uk.gov.hmrc.servicedependencies.controller.ServiceDependenciesController.dependenciesOfSlug(name, version: Option[String])

--- a/test/uk/gov/hmrc/servicedependencies/service/SlugDependenciesServiceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/SlugDependenciesServiceSpec.scala
@@ -29,7 +29,8 @@ import uk.gov.hmrc.servicedependencies.config.CuratedDependencyConfigProvider
 import uk.gov.hmrc.servicedependencies.config.model.CuratedDependencyConfig
 import uk.gov.hmrc.servicedependencies.controller.model.{Dependency, DependencyBobbyRule}
 import uk.gov.hmrc.servicedependencies.model._
-import uk.gov.hmrc.servicedependencies.persistence.{LibraryVersionRepository, SlugInfoRepository}
+import uk.gov.hmrc.servicedependencies.persistence.LibraryVersionRepository
+import uk.gov.hmrc.servicedependencies.service.SlugDependenciesService.TargetVersion.{Labelled, Latest}
 
 import scala.concurrent.Future
 
@@ -38,12 +39,12 @@ class SlugDependenciesServiceSpec extends FreeSpec with MockitoSugar with Matche
   import SlugDependenciesServiceSpec._
 
   private trait Fixture {
-    val slugInfoRepository = mock[SlugInfoRepository]
+    val slugInfoService = mock[SlugInfoService]
     val curatedDependencyConfigProvider = mock[CuratedDependencyConfigProvider]
     val libraryVersionRepository = mock[LibraryVersionRepository]
     val serviceConfigsService = mock[ServiceConfigsService]
 
-    val underTest = new SlugDependenciesService(slugInfoRepository, curatedDependencyConfigProvider,
+    val underTest = new SlugDependenciesService(slugInfoService, curatedDependencyConfigProvider,
       libraryVersionRepository, serviceConfigsService)
 
     def stubCuratedLibrariesOf(libraryNames: String*): Unit =
@@ -81,122 +82,188 @@ class SlugDependenciesServiceSpec extends FreeSpec with MockitoSugar with Matche
 
       when(serviceConfigsService.getDependenciesWithBobbyRules(any[List[Dependency]]())).thenAnswer(withArgumentAsFutureSuccess)
     }
+
+    def stubNoEnrichmentsForDependencies(): Unit = {
+      stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
+      stubNoBobbyRulesViolations()
+    }
+
+    def stubSlugVersionIsUnrecognised(name: String, version: String): Unit =
+      when(slugInfoService.getSlugInfo(name, version)).thenReturn(
+        Future.successful(None)
+      )
   }
 
   "SlugDependenciesService" - {
 
-    "retrieves only the dependencies of a known slug that are curated dependencies" - {
-      "enriched with bobby rules violations" in new Fixture {
-        val dependency1PreViolationEnrichment = Dependency(name = Dependency1.artifact,
-          currentVersion = Version(Dependency1.version), latestVersion = None, bobbyRuleViolations = Nil)
-        val dependency3PreViolationEnrichment = Dependency(name = Dependency3.artifact,
-          currentVersion = Version(Dependency3.version), latestVersion = None, bobbyRuleViolations = Nil)
-        val dependency1RuleViolation = DependencyBobbyRule(reason = "some reason", from = LocalDate.now(), range = BobbyVersionRange("(,9.9.9)"))
-        stubBobbyRulesViolations(
-          dependencies = List(dependency1PreViolationEnrichment, dependency3PreViolationEnrichment),
-          violations = List(List(dependency1RuleViolation), Nil)
-        )
-        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
+    "retrieves slug info by flag when the 'latest' version is requested" - {
+      "returning only curated libraries when the slug is recognised" in new Fixture {
         stubCuratedLibrariesOf(Dependency1.artifact, Dependency3.artifact)
-        when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
-          Future.successful(Seq(slugInfo(withName = SlugName, withVersion = SlugVersion,
-            withDependencies = List(Dependency1, Dependency2, Dependency3))
-          ))
+        stubNoEnrichmentsForDependencies()
+        when(slugInfoService.getSlugInfo(SlugName, flag = SlugInfoFlag.Latest)).thenReturn(
+          Future.successful(
+            Some(slugInfo(withName = SlugName, withVersion = SlugVersion.toString, withDependencies = List(
+              Dependency1, Dependency2, Dependency3
+            )))
+          )
         )
 
-        underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).futureValue.value should contain theSameElementsAs Seq(
-          dependency1PreViolationEnrichment.copy(bobbyRuleViolations = List(dependency1RuleViolation)),
-          dependency3PreViolationEnrichment
-        )
-      }
-
-      "enriched with latest versions when known" in new Fixture {
-        stubNoBobbyRulesViolations()
-        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq(
-          Dependency1.artifact -> LatestVersionOfDependency1, Dependency3.artifact -> LatestVersionOfDependency3
-        ))
-        stubCuratedLibrariesOf(Dependency1.artifact, Dependency3.artifact)
-        when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
-          Future.successful(Seq(slugInfo(withName = SlugName, withVersion = SlugVersion,
-            withDependencies = List(Dependency1, Dependency2, Dependency3))
-          ))
-        )
-
-        underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).futureValue.value should contain theSameElementsAs Seq(
-          Dependency(name = Dependency1.artifact, currentVersion = Version(Dependency1.version), latestVersion = Some(LatestVersionOfDependency1), bobbyRuleViolations = Nil),
-          Dependency(name = Dependency3.artifact, currentVersion = Version(Dependency3.version), latestVersion = Some(LatestVersionOfDependency3), bobbyRuleViolations = Nil)
-        )
-      }
-
-      "without latest versions when not known" in new Fixture {
-        stubNoBobbyRulesViolations()
-        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
-        stubCuratedLibrariesOf(Dependency1.artifact, Dependency3.artifact)
-        when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
-          Future.successful(Seq(slugInfo(withName = SlugName, withVersion = SlugVersion,
-            withDependencies = List(Dependency1, Dependency2, Dependency3))
-          ))
-        )
-
-        underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).futureValue.value should contain theSameElementsAs Seq(
+        underTest.curatedLibrariesOfSlug(SlugName, atVersion = Latest).futureValue.value should contain theSameElementsAs Seq(
           Dependency(name = Dependency1.artifact, currentVersion = Version(Dependency1.version), latestVersion = None, bobbyRuleViolations = Nil),
           Dependency(name = Dependency3.artifact, currentVersion = Version(Dependency3.version), latestVersion = None, bobbyRuleViolations = Nil)
         )
       }
+
+      "returning None when the slug is not recognised" in new Fixture {
+        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
+        when(slugInfoService.getSlugInfo(SlugName, flag = SlugInfoFlag.Latest)).thenReturn(
+          Future.successful(None)
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, atVersion = Latest).futureValue shouldBe None
+      }
+
+      "failing when slug retrieval encounters a failure" in new Fixture {
+        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
+        val failure = new RuntimeException("failed to retrieve slug info by flag")
+        when(slugInfoService.getSlugInfo(SlugName, flag = SlugInfoFlag.Latest)).thenReturn(
+          Future.failed(failure)
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, atVersion = Latest).failed.futureValue shouldBe failure
+      }
     }
 
-    "indicates that the requested slug could not be found by returning None" in new Fixture {
-      stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
-      when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
-        Future.successful(Seq.empty)
-      )
+    "retrieves slug info by version when a specific version is requested" - {
+      "returning only curated libraries when the target slug is recognised" in new Fixture {
+        stubCuratedLibrariesOf(Dependency2.artifact, Dependency3.artifact)
+        stubNoEnrichmentsForDependencies()
+        when(slugInfoService.getSlugInfo(SlugName, version = SlugVersion.toString)).thenReturn(
+          Future.successful(
+            Some(slugInfo(withName = SlugName, withVersion = SlugVersion.toString, withDependencies = List(
+              Dependency1, Dependency2, Dependency3
+            )))
+          )
+        )
 
-      underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).futureValue shouldBe None
+        underTest.curatedLibrariesOfSlug(SlugName, atVersion = Labelled(SlugVersion)).futureValue.value should contain theSameElementsAs Seq(
+          Dependency(name = Dependency2.artifact, currentVersion = Version(Dependency2.version), latestVersion = None, bobbyRuleViolations = Nil),
+          Dependency(name = Dependency3.artifact, currentVersion = Version(Dependency3.version), latestVersion = None, bobbyRuleViolations = Nil)
+        )
+      }
+
+      "returning None when the slug is not recognised" in new Fixture {
+        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
+        stubSlugVersionIsUnrecognised(SlugName, SlugVersion.toString)
+
+        underTest.curatedLibrariesOfSlug(SlugName, atVersion = Labelled(SlugVersion)).futureValue shouldBe None
+      }
+
+      "failing when slug retrieval encounters a failure" in new Fixture {
+        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
+        val failure = new RuntimeException("failed to retrieve slug info by version")
+        when(slugInfoService.getSlugInfo(SlugName, version = SlugVersion.toString)).thenReturn(
+          Future.failed(failure)
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, atVersion = Labelled(SlugVersion)).failed.futureValue shouldBe failure
+      }
     }
 
-    "propagates any failure to retrieve the latest versions of libraries" in new Fixture {
-      val failure = new RuntimeException("failed to retrieve latest library versions")
-      when(libraryVersionRepository.getAllEntries).thenReturn(
-        Future.failed(failure)
-      )
-      when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
-        Future.successful(Seq.empty)
-      )
-
-      underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).failed.futureValue shouldBe failure
-    }
-
-    "propagates any failure to retrieve slug infos" in new Fixture {
-      val failure = new RuntimeException("failed to retrieve slug infos")
-      stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
-      when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
-        Future.failed(failure)
-      )
-
-      underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).failed.futureValue shouldBe failure
-    }
-
-    "propagates any failure to determine bobby rule violations" in new Fixture {
-      stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
-      when(slugInfoRepository.getSlugInfos(SlugName, Some(SlugVersion))).thenReturn(
-        Future.successful(Seq(slugInfo(withName = SlugName, withVersion = SlugVersion,
-          withDependencies = List(Dependency1, Dependency2, Dependency3))
+    "enriches dependencies with latest version information" - {
+      "only adding the latest version when known" in new Fixture {
+        stubNoBobbyRulesViolations()
+        stubCuratedLibrariesOf(Dependency1.artifact, Dependency2.artifact, Dependency3.artifact)
+        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq(
+          Dependency1.artifact -> LatestVersionOfDependency1, Dependency3.artifact -> LatestVersionOfDependency3
         ))
-      )
-      stubCuratedLibrariesOf(Dependency1.artifact, Dependency3.artifact)
-      val failure = new RuntimeException("failed to apply bobby rules")
-      when(serviceConfigsService.getDependenciesWithBobbyRules(any[List[Dependency]])).thenReturn(
-        Future.failed(failure)
-      )
+        when(slugInfoService.getSlugInfo(SlugName, version = SlugVersion.toString)).thenReturn(
+          Future.successful(
+            Some(slugInfo(withName = SlugName, withVersion = SlugVersion.toString, withDependencies = List(
+              Dependency1, Dependency2, Dependency3
+            )))
+          )
+        )
 
-      underTest.curatedLibrariesOfSlug(SlugName, SlugVersion).failed.futureValue shouldBe failure
+        underTest.curatedLibrariesOfSlug(SlugName, atVersion = Labelled(SlugVersion)).futureValue.value should contain theSameElementsAs Seq(
+          Dependency(name = Dependency1.artifact, currentVersion = Version(Dependency1.version), latestVersion = Some(LatestVersionOfDependency1), bobbyRuleViolations = Nil),
+          Dependency(name = Dependency2.artifact, currentVersion = Version(Dependency2.version), latestVersion = None, bobbyRuleViolations = Nil),
+          Dependency(name = Dependency3.artifact, currentVersion = Version(Dependency3.version), latestVersion = Some(LatestVersionOfDependency3), bobbyRuleViolations = Nil)
+        )
+      }
+
+      "failing when retrieval of the latest library versions encounters a failure" in new Fixture {
+        stubSlugVersionIsUnrecognised(SlugName, SlugVersion.toString)
+        val failure = new RuntimeException("failed to retrieve latest library versions")
+        when(libraryVersionRepository.getAllEntries).thenReturn(
+          Future.failed(failure)
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, Labelled(SlugVersion)).failed.futureValue shouldBe failure
+      }
+    }
+
+    "enriches dependencies with Bobby rule violations" - {
+      "only adding rule violations when there are active violations" in new Fixture {
+        stubCuratedLibrariesOf(Dependency1.artifact, Dependency2.artifact, Dependency3.artifact)
+        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
+        val BobbyRuleViolation1 = DependencyBobbyRule(reason = "a reason", from = LocalDate.now(), range = BobbyVersionRange("(,6.6.6)"))
+        val BobbyRuleViolation2 = DependencyBobbyRule(reason = "another reason", from = LocalDate.now(), range = BobbyVersionRange("(,9.9.9)"))
+        stubBobbyRulesViolations(
+          dependencies = List(
+            Dependency(name = Dependency1.artifact, currentVersion = Version(Dependency1.version), latestVersion = None, bobbyRuleViolations = Nil),
+            Dependency(name = Dependency2.artifact, currentVersion = Version(Dependency2.version), latestVersion = None, bobbyRuleViolations = Nil),
+            Dependency(name = Dependency3.artifact, currentVersion = Version(Dependency3.version), latestVersion = None, bobbyRuleViolations = Nil)
+          ),
+          violations = List(
+            List(BobbyRuleViolation1),
+            Nil,
+            List(BobbyRuleViolation1, BobbyRuleViolation2)
+          )
+        )
+
+        when(slugInfoService.getSlugInfo(SlugName, version = SlugVersion.toString)).thenReturn(
+          Future.successful(
+            Some(slugInfo(withName = SlugName, withVersion = SlugVersion.toString, withDependencies = List(
+              Dependency1, Dependency2, Dependency3
+            )))
+          )
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, Labelled(SlugVersion)).futureValue.value should contain theSameElementsAs Seq(
+          Dependency(name = Dependency1.artifact, currentVersion = Version(Dependency1.version), latestVersion = None,
+            bobbyRuleViolations = List(BobbyRuleViolation1)),
+          Dependency(name = Dependency2.artifact, currentVersion = Version(Dependency2.version), latestVersion = None,
+            bobbyRuleViolations = Nil),
+          Dependency(name = Dependency3.artifact, currentVersion = Version(Dependency3.version), latestVersion = None,
+            bobbyRuleViolations = List(BobbyRuleViolation1, BobbyRuleViolation2))
+        )
+      }
+
+      "failing when the retrieval or application of Bobby rules encounters a failure" in new Fixture {
+        stubCuratedLibrariesOf(Dependency1.artifact, Dependency2.artifact, Dependency3.artifact)
+        stubLatestLibraryVersionLookupSuccessfullyReturns(Seq.empty)
+        when(slugInfoService.getSlugInfo(SlugName, version = SlugVersion.toString)).thenReturn(
+          Future.successful(
+            Some(slugInfo(withName = SlugName, withVersion = SlugVersion.toString, withDependencies = List(
+              Dependency1, Dependency2, Dependency3
+            )))
+          )
+        )
+        val failure = new RuntimeException("failed to apply bobby rules")
+        when(serviceConfigsService.getDependenciesWithBobbyRules(any[List[Dependency]])).thenReturn(
+          Future.failed(failure)
+        )
+
+        underTest.curatedLibrariesOfSlug(SlugName, atVersion = Labelled(SlugVersion)).failed.futureValue shouldBe failure
+      }
     }
   }
 }
 
 private object SlugDependenciesServiceSpec {
-  val SlugName = ""
-  val SlugVersion = "1.2.3"
+  val SlugName = "a-slug-name"
+  val SlugVersion = Version(major = 1, minor = 2, patch = 3)
   val Dependency1 = SlugDependency(path = "/path/dep1", version = "1.1.1", group = "com.test.group", artifact = "artifact1")
   val Dependency2 = SlugDependency(path = "/path/dep2", version = "2.2.2", group = "com.test.group", artifact = "artifact2")
   val Dependency3 = SlugDependency(path = "/path/dep3", version = "3.3.3", group = "com.test.group", artifact = "artifact3")


### PR DESCRIPTION
Support retrieval of slug library dependencies for 'latest' if an explicit version is not specified.

Add indexes on slugInfos:
* name, version
* name, latest

to support these queries.  Currently the existing name only index is used, and then all documents for the target service must be scanned to locate the target version / latest slug. 