### PR TITLE
BDOG-938 determine if a slug is latest when adding

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/persistence/derived/DerivedServiceDependenciesRepository.scala
+++ b/app/uk/gov/hmrc/servicedependencies/persistence/derived/DerivedServiceDependenciesRepository.scala
@@ -17,15 +17,14 @@
 package uk.gov.hmrc.servicedependencies.persistence.derived
 
 import javax.inject.Inject
-import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.model.Filters._
+import org.mongodb.scala.model.Indexes.{ascending, compoundIndex}
+import org.mongodb.scala.model.{IndexModel, IndexOptions}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.servicedependencies.model.{ApiServiceDependencyFormats, ServiceDependency, SlugInfoFlag}
 
 import scala.concurrent.{ExecutionContext, Future}
-import org.mongodb.scala.model.Indexes.{ascending, compoundIndex}
-import org.mongodb.scala.model.{IndexModel, IndexOptions}
 
 class DerivedServiceDependenciesRepository @Inject()(mongoComponent: MongoComponent)(implicit ec: ExecutionContext
 ) extends PlayMongoRepository[ServiceDependency](

--- a/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
@@ -40,9 +40,9 @@ class SlugInfoService @Inject()(
 ) extends Logging {
   def addSlugInfo(slug: SlugInfo): Future[Boolean] = {
     for {
-      added <- slugInfoRepository.add(slug)
-
       // Determine which slug is latest from the existing collection, not relying on the potentially stale state of the message
+      added <- slugInfoRepository.add(slug.copy(latest = false))
+
       isLatest        <- slugInfoRepository.getSlugInfos(name = slug.name, optVersion = None)
         .map { case Nil      => true
         case nonempty => val isLatest = nonempty.map(_.version).max == slug.version

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -27,7 +27,7 @@ private object AppDependencies {
     "org.scalatest"          %% "scalatest"               % "3.1.0"              % Test,
     "org.scalatestplus.play" %% "scalatestplus-play"      % "3.1.3"              % Test,
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-27" % hmrcMongoVersion     % Test,
-    "org.mockito"            %% "mockito-scala"           % "1.10.2"             % Test,
+    "org.mockito"            %% "mockito-scala-scalatest" % "1.13.10"            % Test,
     "com.typesafe.play"      %% "play-test"               % PlayVersion.current  % Test,
     "com.github.tomakehurst" %  "wiremock"                % "1.58"               % Test,
     "com.typesafe.akka"      %% "akka-testkit"            % "2.5.26"             % Test

--- a/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
@@ -165,14 +165,14 @@ class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar wi
     }
     "mark the slug as latest if the version is latest" in new GetSlugInfoFixture {
       val slugv1 = sampleSlugInfo.copy(version = Version("1.0.0"), uri = "uri1")
-      val slugv2 = slugv1.copy(version = Version("1.0.0"), uri = "uri2")
+      val slugv2 = slugv1.copy(version = Version("2.0.0"), uri = "uri2")
 
-      when(boot.mockedSlugInfoRepository.getSlugInfos(sampleSlugInfo.name, None)).thenReturn(Future.successful(List(slugv2)))
+      when(boot.mockedSlugInfoRepository.getSlugInfos(sampleSlugInfo.name, None)).thenReturn(Future.successful(List(slugv1, slugv2)))
       when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(true))
       when(boot.mockedSlugInfoRepository.markLatest(any, any)).thenReturn(Future.successful(()))
 
-      boot.service.addSlugInfo(slugv1).futureValue
-      verify(boot.mockedSlugInfoRepository, times(1)).markLatest(sampleSlugInfo.name, Version("1.0.0"))
+      boot.service.addSlugInfo(slugv2).futureValue
+      verify(boot.mockedSlugInfoRepository, times(1)).markLatest(slugv2.name, Version("2.0.0"))
 
       verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
     }

--- a/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 import java.time.Month.DECEMBER
 
 import org.mockito.scalatest.MockitoSugar
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.http.HeaderCarrier
@@ -28,15 +28,14 @@ import uk.gov.hmrc.servicedependencies.connector.{ReleasesApiConnector, TeamsAnd
 import uk.gov.hmrc.servicedependencies.model._
 import uk.gov.hmrc.servicedependencies.persistence.derived.{DerivedGroupArtefactRepository, DerivedServiceDependenciesRepository}
 import uk.gov.hmrc.servicedependencies.persistence.{JdkVersionRepository, SlugInfoRepository}
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with ScalaFutures {
+class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with ScalaFutures with IntegrationPatience {
 
   implicit val hc = HeaderCarrier()
-  override implicit val patienceConfig = PatienceConfig(timeout = 2.seconds, interval = 100.millis)
 
   val group        = "group"
   val artefact     = "artefact"

--- a/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.servicedependencies.service
 import java.time.LocalDateTime
 import java.time.Month.DECEMBER
 
-import org.mockito.MockitoSugar
+import org.mockito.scalatest.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -28,6 +28,7 @@ import uk.gov.hmrc.servicedependencies.connector.{ReleasesApiConnector, TeamsAnd
 import uk.gov.hmrc.servicedependencies.model._
 import uk.gov.hmrc.servicedependencies.persistence.derived.{DerivedGroupArtefactRepository, DerivedServiceDependenciesRepository}
 import uk.gov.hmrc.servicedependencies.persistence.{JdkVersionRepository, SlugInfoRepository}
+import scala.concurrent.duration._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -35,6 +36,7 @@ import scala.concurrent.Future
 class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with ScalaFutures {
 
   implicit val hc = HeaderCarrier()
+  override implicit val patienceConfig = PatienceConfig(timeout = 2.seconds, interval = 100.millis)
 
   val group        = "group"
   val artefact     = "artefact"
@@ -115,10 +117,10 @@ class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar wi
   "SlugInfoService.getSlugInfo" should {
     "support retrieval of a SlugInfo by flag" in new GetSlugInfoFixture {
       when(boot.mockedSlugInfoRepository.getSlugInfo(SlugName, SlugInfoFlag.Latest)).thenReturn(
-        Future.successful(Some(SampleSlugInfo))
+        Future.successful(Some(sampleSlugInfo))
       )
 
-      boot.service.getSlugInfo(SlugName, SlugInfoFlag.Latest).futureValue shouldBe Some(SampleSlugInfo)
+      boot.service.getSlugInfo(SlugName, SlugInfoFlag.Latest).futureValue shouldBe Some(sampleSlugInfo)
     }
 
     "return None when no SlugInfos are found matching the target name and flag" in new GetSlugInfoFixture {
@@ -133,11 +135,11 @@ class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar wi
       val targetVersion = "1.2.3"
       when(boot.mockedSlugInfoRepository.getSlugInfos(SlugName, Some(targetVersion))).thenReturn(
         Future.successful(
-          Seq(SampleSlugInfo)
+          Seq(sampleSlugInfo)
         )
       )
 
-      boot.service.getSlugInfo(SlugName, targetVersion).futureValue shouldBe Some(SampleSlugInfo)
+      boot.service.getSlugInfo(SlugName, targetVersion).futureValue shouldBe Some(sampleSlugInfo)
     }
 
     "return None when no SlugInfos are found matching the target name and version" in new GetSlugInfoFixture {
@@ -147,6 +149,43 @@ class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar wi
       )
 
       boot.service.getSlugInfo(SlugName, targetVersion).futureValue shouldBe None
+    }
+  }
+
+  "SlugInfoService.addSlugInfo" should {
+    "mark the slug as latest if it is the first slug with that name" in new GetSlugInfoFixture {
+      when(boot.mockedSlugInfoRepository.getSlugInfos(sampleSlugInfo.name, None)).thenReturn(Future.successful(List.empty))
+      when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(true))
+      when(boot.mockedSlugInfoRepository.markLatest(any, any)).thenReturn(Future.successful(()))
+
+      boot.service.addSlugInfo(sampleSlugInfo).futureValue
+
+      verify(boot.mockedSlugInfoRepository, times(1)).markLatest(sampleSlugInfo.name, sampleSlugInfo.version)
+      verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
+    }
+    "mark the slug as latest if the version is latest" in new GetSlugInfoFixture {
+      val slugv1 = sampleSlugInfo.copy(version = Version("1.0.0"), uri = "uri1")
+      val slugv2 = slugv1.copy(version = Version("1.0.0"), uri = "uri2")
+
+      when(boot.mockedSlugInfoRepository.getSlugInfos(sampleSlugInfo.name, None)).thenReturn(Future.successful(List(slugv2)))
+      when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(true))
+      when(boot.mockedSlugInfoRepository.markLatest(any, any)).thenReturn(Future.successful(()))
+
+      boot.service.addSlugInfo(slugv1).futureValue
+      verify(boot.mockedSlugInfoRepository, times(1)).markLatest(sampleSlugInfo.name, Version("1.0.0"))
+
+      verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
+    }
+    "not mark the slug as latest if there is a later one already in the collection" in new GetSlugInfoFixture {
+      val slugv1 = sampleSlugInfo.copy(version = Version("1.0.0"), uri = "uri1")
+      val slugv2 = slugv1.copy(version = Version("2.0.0"), uri = "uri2")
+
+      when(boot.mockedSlugInfoRepository.getSlugInfos(sampleSlugInfo.name, None)).thenReturn(Future.successful(List(slugv2)))
+      when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(true))
+
+      boot.service.addSlugInfo(slugv1).futureValue
+
+      verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
     }
   }
 
@@ -191,7 +230,7 @@ class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar wi
 
   private trait GetSlugInfoFixture {
     val SlugName = "a-slug-name"
-    val SampleSlugInfo = SlugInfo(
+    val sampleSlugInfo = SlugInfo(
       uri = "sample-uri",
       created = LocalDateTime.of(2019, DECEMBER, 12, 13, 14),
       name = SlugName,

--- a/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
@@ -176,6 +176,18 @@ class SlugInfoServiceSpec extends AnyWordSpec with Matchers with MockitoSugar wi
 
       verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
     }
+    "not use the latest flag from sqs/artefact processor" in new GetSlugInfoFixture {
+      val slugv1 = sampleSlugInfo.copy(version = Version("1.0.0"), uri = "uri1")
+      val slugv2 = slugv1.copy(version = Version("2.0.0"), uri = "uri2")
+
+      when(boot.mockedSlugInfoRepository.getSlugInfos(sampleSlugInfo.name, None)).thenReturn(Future.successful(List(slugv2)))
+      when(boot.mockedSlugInfoRepository.add(any)).thenReturn(Future.successful(true))
+
+      boot.service.addSlugInfo(slugv1).futureValue
+
+      verify(boot.mockedSlugInfoRepository, times(1)).add(slugv1.copy(latest = false))
+      verifyNoMoreInteractions(boot.mockedSlugInfoRepository)
+    }
     "not mark the slug as latest if there is a later one already in the collection" in new GetSlugInfoFixture {
       val slugv1 = sampleSlugInfo.copy(version = Version("1.0.0"), uri = "uri1")
       val slugv2 = slugv1.copy(version = Version("2.0.0"), uri = "uri2")


### PR DESCRIPTION
1. Instead of using the `latest` flag set by `artefact-processor` verbatim, calculate and update `latest` when adding a new slug. This is a interim measure prior to BDOG-965 where we will review the interplay between the related services.