### PR TITLE
Revert "BDOG-2957: Change how bobby rule range is read to support wildcard"

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/model/BobbyVersionRange.scala
+++ b/app/uk/gov/hmrc/servicedependencies/model/BobbyVersionRange.scala
@@ -57,7 +57,7 @@ object BobbyVersionRange {
   private val qualifier  = """^\[[-\*]+(.*)\]""".r
 
   def parse(range: String): Option[BobbyVersionRange] = {
-    val trimmedRange = if (range.trim == "*") "[0.0.0,)" else range.replaceAll(" ", "")
+    val trimmedRange = range.replaceAll(" ", "")
 
     PartialFunction.condOpt(trimmedRange) {
       case fixed(v) =>

--- a/test/uk/gov/hmrc/servicedependencies/model/BobbyVersionRangeSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/model/BobbyVersionRangeSpec.scala
@@ -22,14 +22,6 @@ import org.scalatest.wordspec.AnyWordSpec
 class BobbyVersionRangeSpec extends AnyWordSpec with Matchers {
 
   "A BobbyVersionRange" should {
-    "read * as '0.0.0 <= x <= ∞'" in {
-      val range = BobbyVersionRange("*")
-
-      range.lowerBound shouldBe Some(BobbyVersion(Version("0.0.0"), inclusive = true))
-      range.upperBound shouldBe None
-      range.qualifier  shouldBe None
-    }
-
     "read (,1.0] as 'x <= 1.0'" in {
       val range = BobbyVersionRange("(,1.0.0]")
 


### PR DESCRIPTION
Reverts hmrc/service-dependencies#253