### PR TITLE
BDOG-3155 only add scala-lang for Scala 2.x

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/controller/ServiceDependenciesController.scala
+++ b/app/uk/gov/hmrc/servicedependencies/controller/ServiceDependenciesController.scala
@@ -291,7 +291,7 @@ class ServiceDependenciesController @Inject()(
                                                                dependencies = compileDependencies,
                                                                group        = "org.scala-lang",
                                                                artefact     = "scala-library",
-                                                               versions     = scalaVersions,
+                                                               versions     = scalaVersions.filter(_ < Version("3.0.0")),  // Scala 3 uses artefact `scala3-language` but it should already be in the Graph
                                                                scope        = DependencyScope.Compile
                                                              )
                                                            ),
@@ -302,7 +302,7 @@ class ServiceDependenciesController @Inject()(
                                                                dependencies = testDependencies,
                                                                group        = "org.scala-lang",
                                                                artefact     = "scala-library",
-                                                               versions     = scalaVersions,
+                                                               versions     = scalaVersions.filter(_ < Version("3.0.0")),
                                                                scope        = DependencyScope.Test
                                                              )
                                                            ),
@@ -312,7 +312,7 @@ class ServiceDependenciesController @Inject()(
                                                                dependencies = itDependencies,
                                                                group        = "org.scala-lang",
                                                                artefact     = "scala-library",
-                                                               versions     = scalaVersions,
+                                                               versions     = scalaVersions.filter(_ < Version("3.0.0")),
                                                                scope        = DependencyScope.It
                                                              )
                                                            ),

--- a/app/uk/gov/hmrc/servicedependencies/util/DependencyGraphParser.scala
+++ b/app/uk/gov/hmrc/servicedependencies/util/DependencyGraphParser.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.servicedependencies.util
 
-import uk.gov.hmrc.servicedependencies.model.{DependencyScope, MetaArtefact}
+import uk.gov.hmrc.servicedependencies.model.{DependencyScope, MetaArtefact, Version}
 
 object DependencyGraphParser {
 
@@ -35,7 +35,7 @@ object DependencyGraphParser {
 
     val scala = meta
                   .modules
-                  .flatMap(_.crossScalaVersions.toSeq.flatten)
+                  .flatMap(_.crossScalaVersions.toSeq.flatten.filter(_ < Version("3.0.0"))) // Scala 3 will already be present in graph if applicable
                   .headOption
                   .map(v => DependencyGraphParser.Node.apply(s"org.scala-lang:scala-library:${v.original}"))
                   .fold(Map.empty[DependencyGraphParser.Node, Set[DependencyScope]])(n => Map(n ->  Set(DependencyScope.Compile, DependencyScope.Test)))

--- a/conf/dependency-versions-config.json
+++ b/conf/dependency-versions-config.json
@@ -6,6 +6,7 @@
   "libraries": [
     { "group": "org.reactivemongo", "name": "reactivemongo"  , "latestVersion": "0.20.3" },
     { "group": "org.scala-lang"   , "name": "scala-library"  , "latestVersion": "2.13.12" },
+    { "group": "org.scala-lang"   , "name": "scala3-library" , "latestVersion": "3.3.3" },
     { "group": "com.typesafe.play", "name": "play"           , "latestVersion": "2.9.3" },
     { "group": "org.playframework", "name": "play"           , "latestVersion": "3.0.3" }
   ],


### PR DESCRIPTION
Scala 3 uses artefact scala3-lang, and it is already present in the graph