### PR TITLE
Fix duplicate latest data

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/persistence/MetaArtefactRepository.scala
+++ b/app/uk/gov/hmrc/servicedependencies/persistence/MetaArtefactRepository.scala
@@ -40,6 +40,7 @@ class MetaArtefactRepository @Inject()(
   indexes        = Seq(
                      IndexModel(Indexes.ascending("name", "version"), IndexOptions().unique(true)),
                      IndexModel(Indexes.compoundIndex(Indexes.ascending("name"), Indexes.hashed("latest"))),
+                     IndexModel(Indexes.ascending("name"), IndexOptions().unique(true).partialFilterExpression(Filters.equal("latest", true))),
                      IndexModel(Indexes.hashed("latest"))
                    ),
   replaceIndexes = true
@@ -62,7 +63,7 @@ class MetaArtefactRepository @Inject()(
                                       Filters.equal("name"   , meta.name)
                                     , Filters.equal("version", meta.version.toString)
                                     )
-                  , replacement   = meta
+                  , replacement   = meta.copy(latest = false) // this will be set appropriately next
                   , options       = ReplaceOptions().upsert(true)
                   )
                   .toFuture()

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,7 +12,7 @@ private object AppDependencies {
     caffeine,
     "uk.gov.hmrc"            %% "bootstrap-backend-play-30" % bootstrapPlayVersion,
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
-    "org.typelevel"          %% "cats-core"                 % "2.10.0",
+    "org.typelevel"          %% "cats-core"                 % "2.12.0",
     "org.apache.commons"     %  "commons-compress"          % "1.20",
     "software.amazon.awssdk" %  "sqs"                       % "2.27.3"
   )


### PR DESCRIPTION
Latest cats has a more efficient traverse which brought to light that parallel MetaArtefactRepository.put were leading to duplicated latest flag.
Adding the index ensures that transactions are retried if their invariants are invalidated.