### PR TITLE
BDOG-3710: Limit JDK usage query to active repositories

### DIFF
--- a/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
+++ b/app/uk/gov/hmrc/servicedependencies/service/SlugInfoService.scala
@@ -67,14 +67,10 @@ class SlugInfoService @Inject()(
     derivedGroupArtefactRepository.findGroupsArtefacts()
 
   def findJDKVersions(teamName: Option[String], digitalService: Option[String], flag: SlugInfoFlag)(using hc: HeaderCarrier): Future[Seq[JDKVersion]] =
-    (teamName, digitalService) match
-      case (None, None) => jdkVersionRepository.findJDKUsage(flag)
-      case _            =>
-                           for
-                             repos <- teamsAndRepositoriesConnector.getAllRepositories(archived = Some(false), teamName = teamName, digitalService = digitalService)
-                             xs    <- jdkVersionRepository.findJDKUsage(flag)
-                           yield xs.filter(x => repos.exists(_.name == x.name))
-
+     for
+       repos <- teamsAndRepositoriesConnector.getAllRepositories(archived = Some(false), teamName = teamName, digitalService = digitalService)
+       xs    <- jdkVersionRepository.findJDKUsage(flag)
+     yield xs.filter(x => repos.exists(_.name == x.name))
   def findSBTVersions(teamName: Option[String], digitalService: Option[String], flag: SlugInfoFlag)(using hc: HeaderCarrier): Future[Seq[SBTVersion]] =
     (teamName, digitalService) match
       case (None, None) => sbtVersionRepository.findSBTUsage(flag) // for Latest, we could get the data from MetaArtefact to support non-services

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 private object AppDependencies {
   import play.sbt.PlayImport.caffeine
 
-  val bootstrapPlayVersion = "10.6.0"
+  val bootstrapPlayVersion = "10.7.0"
   val hmrcMongoVersion     = "2.12.0"
 
   val compile = Seq(

--- a/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
+++ b/test/uk/gov/hmrc/servicedependencies/service/SlugInfoServiceSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.servicedependencies.connector.TeamsAndRepositoriesConnector
+import uk.gov.hmrc.servicedependencies.connector.TeamsAndRepositoriesConnector.Repository
 import uk.gov.hmrc.servicedependencies.model._
 import uk.gov.hmrc.servicedependencies.persistence.{DeploymentRepository, JdkVersionRepository, SbtVersionRepository, SlugInfoRepository, SlugVersionRepository}
 import uk.gov.hmrc.servicedependencies.persistence.derived.DerivedGroupArtefactRepository
@@ -152,6 +153,39 @@ class SlugInfoServiceSpec
       boot.service.addSlugInfo(slugv1).futureValue
 
       verifyNoMoreInteractions(boot.mockedDeploymentRepository)
+    }
+  }
+
+  "SlugInfoService.findJDKVersions" should {
+    "return only JDK versions for active repositories" in new GetSlugInfoFixture {
+      val teamName       = Some("team-a")
+      val digitalService = Some("digital-service-a")
+      val flag           = SlugInfoFlag.Latest
+      val repos = Seq(
+        Repository("service-1", Seq("team-a"), Some("digital-service-a"), RepoType.Service, isArchived = false),
+        Repository("service-3", Seq("team-a"), Some("digital-service-a"), RepoType.Service, isArchived = false),
+        Repository("service-4", Seq("team-a"), Some("digital-service-a"), RepoType.Service, isArchived = true)
+      )
+      val jdkVersions = Seq(
+        JDKVersion(name = "service-1", version = "17.0.12", vendor = "Temurin", kind = "jdk"),
+        JDKVersion(name = "service-2", version = "21.0.4", vendor = "Temurin", kind = "jdk"),
+        JDKVersion(name = "service-3", version = "17.0.25", vendor = "Temurin", kind = "jdk"),
+        JDKVersion(name = "service-4", version = "21.0.4", vendor = "Temurin", kind = "jdk")
+      )
+
+      when(boot.mockedTeamsAndRepositoriesConnector.getAllRepositories(archived = Some(false), teamName = teamName, digitalService = digitalService))
+        .thenReturn(Future.successful(repos.filter(_.isArchived == false)))
+      when(boot.mockedJdkVersionRepository.findJDKUsage(flag))
+        .thenReturn(Future.successful(jdkVersions))
+
+      boot.service.findJDKVersions(teamName, digitalService, flag).futureValue shouldBe(
+        Seq(
+          JDKVersion(name = "service-1", version = "17.0.12", vendor = "Temurin", kind = "jdk"),
+          JDKVersion(name = "service-3", version = "17.0.25", vendor = "Temurin", kind = "jdk")
+        )
+      )
+
+      verify(boot.mockedJdkVersionRepository).findJDKUsage(flag)
     }
   }
 


### PR DESCRIPTION
The existing method matched on whether a `service` and/or a `team` are provided, and when neither was, the next call queried `slugInfos` without filtering results against active repositories. A total of 8 results (out of 1600+) are now excluded:

```
[
paye-core-helpdesk,
paye-filing-exb-helpdesk,
paye-filing-helpdesk,
print-and-post-forms-aem-publisher,
sa-filing-2223-helpdesk,
sa-filing-2324-helpdesk,
sa-filing-2425-helpdesk,
sa-filing-2526-helpdesk
]
```